### PR TITLE
Enable HFS+ filesystem in linux-sunxi-next.config

### DIFF
--- a/config/linux-sunxi-next.config
+++ b/config/linux-sunxi-next.config
@@ -2529,8 +2529,8 @@ CONFIG_MISC_FILESYSTEMS=y
 # CONFIG_ADFS_FS is not set
 # CONFIG_AFFS_FS is not set
 # CONFIG_ECRYPT_FS is not set
-# CONFIG_HFS_FS is not set
-# CONFIG_HFSPLUS_FS is not set
+CONFIG_HFS_FS=y
+CONFIG_HFSPLUS_FS=y
 # CONFIG_BEFS_FS is not set
 # CONFIG_BFS_FS is not set
 # CONFIG_EFS_FS is not set


### PR DESCRIPTION
enable HFS/HFS+ filesystem to be able to acess Mac Harddrives