### PR TITLE
Update deboostrap.sh

### DIFF
--- a/deboostrap.sh
+++ b/deboostrap.sh
@@ -121,7 +121,7 @@ LC_ALL=C LANGUAGE=C LANG=C chroot $DEST/output/sdcard /bin/bash -c "apt-get -y -
 if [ -f $DEST/output/sdcard/etc/locale.gen ]; then sed -i "s/^# $DEST_LANG/$DEST_LANG/" $DEST/output/sdcard/etc/locale.gen; fi
 LC_ALL=C LANGUAGE=C LANG=C chroot $DEST/output/sdcard /bin/bash -c "locale-gen $DEST_LANG"
 LC_ALL=C LANGUAGE=C LANG=C chroot $DEST/output/sdcard /bin/bash -c "export CHARMAP=$CONSOLE_CHAR FONTFACE=8x16 LANG=$DEST_LANG LANGUAGE=$DEST_LANG DEBIAN_FRONTEND=noninteractive"
-LC_ALL=C LANGUAGE=C LANG=C chroot $DEST/output/sdcard /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=POSIX"
+LC_ALL=C LANGUAGE=C LANG=C chroot $DEST/output/sdcard /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=POSIX LC_ALL=$DEST_LANG"
 
 chroot $DEST/output/sdcard /bin/bash -c "debconf-apt-progress -- apt-get -y install $PAKETKI"
 


### PR DESCRIPTION
Fix for language bug as proposed from mk01 needs change to compile.sh too for german

# user 
DEST_LANG="de_DE.UTF-8"                     # sl_SI.UTF-8, en_US.UTF-8
CONSOLE_CHAR="UTF-8"                        # console charset
TZDATA="Europe/Berlin"                      # time zone

after boot you can change from english to german keyboard layout on console by typing
loadkeys de

http://forum.solid-run.com/linux-on-cubox-i-and-hummingboard-f8/debian-wheezy-server-wifi-bt-ir-i2s-spi-update-6-6-t1573-s400.html#p18660