### PR TITLE
Pick the latest of multiple stable versions

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -50,7 +50,7 @@ MISC5_DIR="sunxi-display-changer"						# local directory
 #-----------------------------------------------------------------------------------------------------------------------------------
 # If KERNELTAG is not defined, let's compile latest stable. Vanilla kernel only
 #-----------------------------------------------------------------------------------------------------------------------------------
-[[ -z "$KERNELTAG" ]] && KERNELTAG="v"`wget -qO-  https://www.kernel.org/finger_banner | grep "The latest st" | awk '{print $NF}'`
+[[ -z "$KERNELTAG" ]] && KERNELTAG="v"`wget -qO-  https://www.kernel.org/finger_banner | grep "The latest st" | awk 'NR==1{print $NF}'`
 
 
 #-----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Resolve #132

As of today, the www.kernel.org/finger_banner returns two stable versions - one each for 4.3.x and 4.2.x

The default value of KERNELTAG is set to choose the "latest" (technically, it's set to choose the version mentioned first in the page) of these minor versions when multiple versions exists.