### PR TITLE
Enable audio capture for Cubieboard2

### DIFF
--- a/config/cubieboard2.fex
+++ b/config/cubieboard2.fex
@@ -1190,7 +1190,9 @@ spdif_din           =
 
 [audio_para]
 audio_used          = 1
-audio_pa_ctrl        = port:PH15<1><default><default><1>
+audio_pa_ctrl       = port:PH15<1><default><default><1>
+playback_used       = 1
+capture_used        = 1
 
 [switch_para]
 switch_used         = 1


### PR DESCRIPTION
Enable audio capture for Cubieboard2 via Line-In jack