### PR TITLE
Change PPS to module and enable PPS_GPIO

### DIFF
--- a/config/linux-sunxi-next.config
+++ b/config/linux-sunxi-next.config
@@ -2435,7 +2435,7 @@ CONFIG_SPI_SPIDEV=m
 #
 # PPS support
 #
-CONFIG_PPS=y
+CONFIG_PPS=m
 # CONFIG_PPS_DEBUG is not set
 
 #
@@ -2444,7 +2444,7 @@ CONFIG_PPS=y
 # CONFIG_PPS_CLIENT_KTIMER is not set
 # CONFIG_PPS_CLIENT_LDISC is not set
 # CONFIG_PPS_CLIENT_PARPORT is not set
-# CONFIG_PPS_CLIENT_GPIO is not set
+CONFIG_PPS_CLIENT_GPIO=m
 
 #
 # PPS generators support


### PR DESCRIPTION
There is no need to have CONFIG_PPS hardlinked in the kernel, esp not without a client driver to drive the PPS (Pulse Per Second) device.
Also enabled the CONFIG_PPS_GPIO as module to drive the PPS device (which is the most use full driver on all the embedded boards).