### PR TITLE
Set DRAM clockspeed also to 624MHz in fex files, a few more fex fixes

### DIFF
--- a/config/orangepi2.fex
+++ b/config/orangepi2.fex
@@ -173,7 +173,7 @@ pll_de           = 864
 ;
 ;*****************************************************************************
 [dram_para]
-dram_clk        = 672
+dram_clk        = 624
 dram_type       = 3
 dram_zq         = 0x3b3bfb
 dram_odt_en     = 0x1
@@ -759,7 +759,7 @@ sdc_ddrmode       = 1
 ; sim card configuration
 ;--------------------------------------------------------------------------------
 [smc_para]
-smc_used            =
+smc_used            = 0
 smc_rst             = port:PA09<2><default><default><default>
 smc_vppen           = port:PA20<3><default><default><default>
 smc_vppp            = port:PA21<3><default><default><default>
@@ -1248,6 +1248,15 @@ d7s_used				= 0
 din_gpio				= port:PD00<1><default><default><1>
 clk_gpio				= port:PD01<1><default><default><1>
 stb_gpio				= port:PD02<1><default><default><1>
+
+;----------------------------------------------------------------------------------
+;mali parameters
+;----------------------------------------------------------------------------------
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
 
 ;----------------------------------------------------------------------------------
 ;1wire parameters (default - PA20)

--- a/config/orangepilite.fex
+++ b/config/orangepilite.fex
@@ -106,7 +106,7 @@ pll_periph1 = 600
 pll_de = 864
 
 [dram_para]
-dram_clk = 672
+dram_clk = 624
 dram_type = 3
 dram_zq = 0x3b3bfb
 dram_odt_en = 1
@@ -503,7 +503,7 @@ sdc_2xmode = 1
 sdc_ddrmode = 1
 
 [smc_para]
-smc_used =
+smc_used = 0
 smc_rst = port:PA09<2><default><default><default>
 smc_vppen = port:PA20<3><default><default><default>
 smc_vppp = port:PA21<3><default><default><default>
@@ -823,3 +823,18 @@ din_gpio = port:PD00<1><default><default><1>
 clk_gpio = port:PD01<1><default><default><1>
 stb_gpio = port:PD02<1><default><default><1>
 
+;----------------------------------------------------------------------------------
+;mali parameters
+;----------------------------------------------------------------------------------
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
+
+;----------------------------------------------------------------------------------
+;1wire parameters (default - PA20)
+;----------------------------------------------------------------------------------
+[w1_para]
+w1_used = 1
+gpio = 20

--- a/config/orangepione.fex
+++ b/config/orangepione.fex
@@ -106,7 +106,7 @@ pll_periph1 = 600
 pll_de = 864
 
 [dram_para]
-dram_clk = 672
+dram_clk = 624
 dram_type = 3
 dram_zq = 0x3b3bfb
 dram_odt_en = 1
@@ -503,7 +503,7 @@ sdc_2xmode = 1
 sdc_ddrmode = 1
 
 [smc_para]
-smc_used =
+smc_used = 0
 smc_rst = port:PA09<2><default><default><default>
 smc_vppen = port:PA20<3><default><default><default>
 smc_vppp = port:PA21<3><default><default><default>
@@ -821,6 +821,15 @@ d7s_used = 0
 din_gpio = port:PD00<1><default><default><1>
 clk_gpio = port:PD01<1><default><default><1>
 stb_gpio = port:PD02<1><default><default><1>
+
+;----------------------------------------------------------------------------------
+;mali parameters
+;----------------------------------------------------------------------------------
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
 
 ;----------------------------------------------------------------------------------
 ;1wire parameters (default - PA20)

--- a/config/orangepipc.fex
+++ b/config/orangepipc.fex
@@ -106,7 +106,7 @@ pll_periph1 = 600
 pll_de = 864
 
 [dram_para]
-dram_clk = 672
+dram_clk = 624
 dram_type = 3
 dram_zq = 0x3b3bfb
 dram_odt_en = 1
@@ -505,7 +505,7 @@ sdc_2xmode = 1
 sdc_ddrmode = 1
 
 [smc_para]
-smc_used =
+smc_used = 0
 smc_rst = port:PA09<2><default><default><default>
 smc_vppen = port:PA20<3><default><default><default>
 smc_vppp = port:PA21<3><default><default><default>
@@ -834,6 +834,15 @@ d7s_used = 0
 din_gpio = port:PD00<1><default><default><1>
 clk_gpio = port:PD01<1><default><default><1>
 stb_gpio = port:PD02<1><default><default><1>
+
+;----------------------------------------------------------------------------------
+;mali parameters
+;----------------------------------------------------------------------------------
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
 
 ;----------------------------------------------------------------------------------
 ;1wire parameters (default - PA20)

--- a/config/orangepiplus.fex
+++ b/config/orangepiplus.fex
@@ -796,7 +796,7 @@ sdc_ddrmode       = 1
 ; sim card configuration
 ;--------------------------------------------------------------------------------
 [smc_para]
-smc_used            =
+smc_used            = 0
 smc_rst             = port:PA09<2><default><default><default>
 smc_vppen           = port:PA20<3><default><default><default>
 smc_vppp            = port:PA21<3><default><default><default>


### PR DESCRIPTION
DRAM clockspeed has also be defined correctly in fex files and where we use 624 MHz in u-boot we should define the same value in the fex file. Since otherwise when thermal throttling occurs or the 'cooling state' changes, DRAM clock will be adjusted to 480MHz and then to the value defined in the fex file.