### PR TITLE
Fixes compilation of e.g. udl as a module

### DIFF
--- a/patch/kernel/sun8i-default/export_read_current_timer.patch
+++ b/patch/kernel/sun8i-default/export_read_current_timer.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm/kernel/armksyms.c b/arch/arm/kernel/armksyms.c
+index 60d3b73..e7a29fe 100644
+--- a/arch/arm/kernel/armksyms.c
++++ b/arch/arm/kernel/armksyms.c
+@@ -156,3 +156,7 @@  EXPORT_SYMBOL(__gnu_mcount_nc);
+ #ifdef CONFIG_ARM_PATCH_PHYS_VIRT
+ EXPORT_SYMBOL(__pv_phys_offset);
+ #endif
++
++#ifdef CONFIG_ARM_ARCH_TIMER
++EXPORT_SYMBOL(read_current_timer);
++#endif


### PR DESCRIPTION
When compiling udl as a module it'd error out on missing symbol for read_current_timer. This patch, taken from https://patchwork.kernel.org/patch/1540031/, fixes that.