### PR TITLE
motd will show now banana pro instead banana

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -111,7 +111,7 @@ if [[ $MACHINE == *Orange* ]]; then ID="Orange"; fi
 if [[ $MACHINE == *Neo* ]]; then ID="Udoo Neo"; fi
 if [[ $MACHINE == *Cubietruck* ]]; then ID="Cubietruck"; fi
 if [[ $MACHINE == *Cubieboard* ]]; then ID="Cubieboard"; fi
-
+if [[ $MACHINE == *Pro* ]]; then ID="Banana Pro"; fi
 if [[ $MACHINE == *M2* ]]; then ID="Banana M2"; fi
 
 echo -e "[\e[0;32m ok \x1B[0m] Starting ARM hardware info: $ID"


### PR DESCRIPTION
if the dtb file is properly linked to banana pro aka Lemaker Banana Pro. _This way is posible to recognice if the dtb changed to the default banana pi during some future upgrade._

