### PR TITLE
Build driver for MT7601U

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -324,6 +324,69 @@ if [[ -n "$MISC5_DIR" && $BRANCH != "next" && $LINUXSOURCEDIR == *sunxi* ]]; the
 	(make ARCH=arm CC=arm-linux-gnueabihf-gcc KSRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
 	install -m 755 a10disp $DEST/cache/sdcard/usr/local/bin
 fi
+
+# MT7601U
+if [[ -n "$MISC6_DIR" && $BRANCH != "next" ]]; then
+	display_alert "Installing external applications" "MT7601U - driver" "info"
+	cd $SOURCES/$MISC6_DIR
+	cat >> fix_build.patch << _EOF_
+diff --git a/src/dkms.conf b/src/dkms.conf
+new file mode 100644
+index 0000000..7563b5a
+--- /dev/null
++++ b/src/dkms.conf
+@@ -0,0 +1,8 @@
++PACKAGE_NAME="mt7601-sta-dkms"
++PACKAGE_VERSION="3.0.0.4"
++CLEAN="make clean"
++BUILT_MODULE_NAME[0]="mt7601Usta"
++BUILT_MODULE_LOCATION[0]="./os/linux/"
++DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless"
++AUTOINSTALL=yes
++MAKE[0]="make -j4 KERNELVER=\$kernelver"
+diff --git a/src/include/os/rt_linux.h b/src/include/os/rt_linux.h
+index 3726b9e..b8be886 100755
+--- a/src/include/os/rt_linux.h
++++ b/src/include/os/rt_linux.h
+@@ -279,7 +279,7 @@ typedef struct file* RTMP_OS_FD;
+ 
+ typedef struct _OS_FS_INFO_
+ {
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,12,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+ 	uid_t				fsuid;
+ 	gid_t				fsgid;
+ #else
+diff --git a/src/os/linux/rt_linux.c b/src/os/linux/rt_linux.c
+index 1b6a631..c336611 100755
+--- a/src/os/linux/rt_linux.c
++++ b/src/os/linux/rt_linux.c
+@@ -51,7 +51,7 @@
+ #define RT_CONFIG_IF_OPMODE_ON_STA(__OpMode)
+ #endif
+ 
+-ULONG RTDebugLevel = RT_DEBUG_TRACE;
++ULONG RTDebugLevel = 0;
+ ULONG RTDebugFunc = 0;
+ 
+ #ifdef OS_ABL_FUNC_SUPPORT
+_EOF_
+
+	patch -p1 < fix_build.patch
+	cd src
+	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- clean >/dev/null 2>&1
+	(make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LINUX_SRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
+	cp os/linux/*.ko $DEST/cache/sdcard/lib/modules/$VER-$LINUXFAMILY/kernel/net/wireless/
+	mkdir -p $DEST/cache/sdcard/etc/Wireless/RT2870STA
+	cp RT2870STA.dat $DEST/cache/sdcard/etc/Wireless/RT2870STA/
+	depmod -b $DEST/cache/sdcard/ $VER-$LINUXFAMILY
+	make clean 1>&2 2>/dev/null
+	cd ..
+	mkdir -p $DEST/cache/sdcard/usr/src/
+	cp -R src $DEST/cache/sdcard/usr/src/mt7601-3.0.0.4
+	# TODO: Set the module to build automatically via dkms in the future here
+
+fi
 }
 
 

--- a/configuration.sh
+++ b/configuration.sh
@@ -49,6 +49,8 @@
 	MISC4_DIR=""
 	MISC5="https://github.com/hglm/a10disp/" # Display changer for Allwinner
 	MISC5_DIR="sunxi-display-changer" # local directory
+	MISC6="https://github.com/porjo/mt7601/" # Display changer for Allwinner
+	MISC6_DIR="mt7601" # local directory
 
 
 

--- a/main.sh
+++ b/main.sh
@@ -254,6 +254,7 @@ if [[ -n "$MISC2" ]]; then fetch_from_github "$MISC2" "$MISC2_DIR"; fi
 if [[ -n "$MISC3" ]]; then fetch_from_github "$MISC3" "$MISC3_DIR"; fi
 if [[ -n "$MISC4" ]]; then fetch_from_github "$MISC4" "$MISC4_DIR"; fi
 if [[ -n "$MISC5" ]]; then fetch_from_github "$MISC5" "$MISC5_DIR"; fi
+if [[ -n "$MISC6" ]]; then fetch_from_github "$MISC6" "$MISC6_DIR"; fi
 
 # compile sunxi tools
 if [[ $LINUXFAMILY == sun*i ]]; then 


### PR DESCRIPTION
Builds a driver for MT7601U on the 3.4 - kernel and sets it up in the image so it could be used by dkms in the future (currently the images don't include dkms.)