### PR TITLE
Revert to normal cpufreq settings for OPi One/Lite, …

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -256,7 +256,7 @@
 			MODULES="gpio_sunxi w1-sunxi w1-gpio w1-therm"
 			MODULES_NEXT=""
 			CPUMIN="648000"
-			CPUMAX="1104000"
+			CPUMAX="1200000"
 			GOVERNOR="interactive"
 		;;
 
@@ -268,7 +268,7 @@
 			MODULES="8189es gpio_sunxi w1-sunxi w1-gpio w1-therm"
 			MODULES_NEXT=""
 			CPUMIN="648000"
-			CPUMAX="1104000"
+			CPUMAX="1200000"
 			GOVERNOR="interactive"
 		;;
 

--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -24,7 +24,7 @@ LEDS=$(grep "green:ph02:led1" "${TMPFILE}")
 TERMINUS=$(lsusb | grep "1a40:0101")
 SWITCH=$(grep "BCM53125" "${TMPFILE}")
 INTERUPT=$(grep "eth0" /proc/interrupts)
-WIFI8189ES=$(lsmod | grep 8189es)
+WIFI8189ES=$(lsmod | grep 8189es | grep -v "0 $" | grep -v "0$") # ignore when not loaded
 
 case "$1" in
     start)
@@ -55,15 +55,16 @@ if [ "$ARCH" = "armv7l" ]; then
 	fi
 	if [ $HARDWARE = "sun8i" ]; then
 		ID="Orange H3"
+		# redistribute USB irqs to dedicated cores
+		echo 2 >/proc/irq/$(awk -F":" '/usb2/ {print $1}' </proc/interrupts)/smp_affinity
+		echo 4 >/proc/irq/$(awk -F":" '/usb3/ {print $1}' </proc/interrupts)/smp_affinity 2>/dev/null # OPi One
 		if [ "$TERMINUS" != "" ]; then
+			# Ethernet irqs on cpu3
+			echo 8 >/proc/irq/$(awk -F":" '/gmac0/ {print $1}' </proc/interrupts)/smp_affinity
 			ID="Orange Pi+"
 			if [ $MEMTOTAL -gt 1500 ]; then
 				ID="Orange Pi+ 2"
 			fi
-			# redistribute USB irqs to dedicated cores
-			echo 2 >/proc/irq/$(awk -F":" '/usb2/ {print $1}' </proc/interrupts)/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" '/usb3/ {print $1}' </proc/interrupts)/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" '/gmac0/ {print $1}' </proc/interrupts)/smp_affinity
 			case ${ORANGEPIPHY} in
 			00441400*)
 				if [ "$WIFI8189ES" != "" ]; then
@@ -75,11 +76,9 @@ if [ "$ARCH" = "armv7l" ]; then
 			esac
 		elif [ "$WIFI8189ES" != "" ]; then
 			ID="Orange Pi Lite"
+			echo 8 >/proc/irq/$(awk -F":" '/wlan0/ {print $1}' </proc/interrupts)/smp_affinity
 		elif [ $MEMTOTAL -gt 600 ]; then
 			ID="Orange Pi PC"
-			# redistribute USB irqs to dedicated cores
-			echo 2 >/proc/irq/$(awk -F":" '/usb2/ {print $1}' </proc/interrupts)/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" '/usb3/ {print $1}' </proc/interrupts)/smp_affinity
 			echo 8 >/proc/irq/$(awk -F":" '/usb4/ {print $1}' </proc/interrupts)/smp_affinity
 		else
 			ID="Orange Pi One"
@@ -146,6 +145,7 @@ if [[ $MACHINE == *M2* ]]; then ID="Banana M2"; fi
 
 echo -e "[\e[0;32m ok \x1B[0m] Starting ARM hardware info: $ID"
 echo $ID >> /var/run/machine.id
+export HARDWARE DISTROID DISTROCODE ARCH KERNELID MACHINE ID
 ;;
 stop|reload|restart|force-reload|status)
 echo -e "[\e[0;32m ok \x1B[0m] Stopping ARM hardware info ..."

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -23,7 +23,7 @@ cat > /tmp/create_swap.sh <<EOT
 # SSH Keys creation
 rm -f /etc/ssh/ssh_host*
 dpkg-reconfigure openssh-server >/dev/null 2>&1
-MEMTOTAL=\$(awk 'BEGIN { printf "%.0f\n", '\$(grep MemTotal /proc/meminfo | awk '{print \$2}')'/1024/1024 }')
+MEMTOTAL=$(( $(awk -F" " '/^MemTotal/ {print $2}' </proc/meminfo) / 1024 ))
 FREESIZE=\$(df -hm / | awk '/\// {print \$(NF-2)}')
 if [[ ! -f "/var/swap" && "\$FREESIZE" -gt "132" ]]; then
 dd if=/dev/zero of=/var/swap bs=1024 count=131072 status=noxfer >/dev/null 2>&1
@@ -42,9 +42,13 @@ fi
 if [[ "$(apt-cache policy ramlog | grep Installed)" != "" ]]; then
 	service ramlog enable
 	# if we have 1G ram reduce RAMLOG size 
-	if [[ "\$MEMTOTAL" -le "1" ]]; then
+	if [[ "\$MEMTOTAL" -lt "1100" ]]; then
 		if [ -f "/etc/default/ramlog" ]; then					
 			sed -e 's/TMPFS_RAMFS_SIZE=512m/TMPFS_RAMFS_SIZE=256m/g' -i /etc/default/ramlog
+		fi
+	elif [[ "\$MEMTOTAL" -lt "600" ]]; then
+		if [ -f "/etc/default/ramlog" ]; then					
+			sed -e 's/TMPFS_RAMFS_SIZE=512m/TMPFS_RAMFS_SIZE=192m/g' -i /etc/default/ramlog
 		fi
 	fi
 fi
@@ -61,47 +65,83 @@ chmod +x /tmp/create_swap.sh
 #
 # get some info about the board
 CURKERNE=$(uname -r | sed 's/\([0-9]\+\.[0-9]\+\)\..*/\1/')
-MACHINE=$(cat /run/machine.id)
 DISTRIBUTION=$(lsb_release -cs)
+HARDWARE=$(awk '/Hardware/ {print $3}' </proc/cpuinfo)
 
 root_device=$(mountpoint -d /)
 for file in /dev/* ; do
 CURRENT_DEVICE=$(printf "%d:%d" $(stat --printf="0x%t 0x%T" $file))
 if [ $CURRENT_DEVICE = $root_device ]; then
-		root_partition=$file
-		break;
+	root_partition=$file
+	break;
 fi
 done
 rootfstype=$(blkid -s TYPE -o value $root_partition)
 set -e
 
-display_alert()
-{
-if [ "$DISTRIBUTION" == "wheezy" ]; then
-echo -e "[\e[0;32m ok \x1B[0m] $1" > /dev/tty1
-else
-echo -e " * $1" > /dev/tty1
-fi
+display_alert() {
+	if [ "$DISTRIBUTION" == "wheezy" ]; then
+		echo -e "[\e[0;32m ok \x1B[0m] $1" > /dev/tty1
+	else
+		echo -e " * $1" > /dev/tty1
+	fi
 }
 
-do_expand_rootfs(){
-		device="/dev/"$(lsblk -idn -o NAME | grep mmcblk0)
-		PARTITIONS=$(($(fdisk -l $device | grep $device | wc -l)-1))
-		PARTSTART=$(parted $device unit s print -sm | tail -1 | cut -d: -f2 | sed 's/s//') # start of first partition
-		PARTEND=$(parted $device unit s print -sm | head -3 | tail -1 | cut -d: -f3 | sed 's/s//') # end of first partition
-		STARTFROM=$(($PARTEND+1))
-		[[ $PARTITIONS == 1 ]] && STARTFROM=$PARTSTART
-		((echo d; echo $PARTITIONS; echo n; echo p; echo ; echo $STARTFROM; echo ; echo w;) | fdisk $device) >/dev/null || true
-		s=0	
-		fsck -f $root_partition >/dev/null 2>&1 || true
-		partprobe $device >/dev/null 2>&1 || s=$?
-		resize2fs $root_partition >/dev/null 2>&1 || true
-		FREESIZE=$(df -hm / | awk '/\// {print $(NF-2)}')
-		if [[ "$DISTRIBUTION" == "wheezy" || "$s" != "0" || "$FREESIZE" -lt "152" ]]; then
-			touch /var/run/reboot
-			display_alert "Automatic reboot is needed. Please wait"
-			update-rc.d resize2fs defaults >/dev/null 2>&1 
-		fi
+autodetect_h3() {
+	# This function adjusts script.bin and cpufreq settings based on /run/machine.id so
+	# that a single OS image built for Orange Pi Plus can be shipped.
+	
+	# wait for armhwinfo
+	sleep 3
+	read MACHINE </run/machine.id
+	case ${MACHINE} in
+		"Orange Pi+"*)
+			:
+			;;
+		"Orange Pi 2"*)
+			ln -sf /boot/bin/orangepi2.bin /boot/script.bin
+			;;
+		"Orange Pi PC")
+			ln -sf /boot/bin/orangepipc.bin /boot/script.bin
+			;;
+		"Orange Pi One")
+			ln -sf /boot/bin/orangepione.bin /boot/script.bin
+			sed -i -e 's/MIN_SPEED=480000/MIN_SPEED=648000/' \
+			-e 's/MAX_SPEED=1296000/MAX_SPEED=1200000/' /etc/default/cpufrequtils
+			;;
+		"Orange Pi Lite")
+			ln -sf /boot/bin/orangepilite.bin /boot/script.bin
+			sed -i -e 's/MIN_SPEED=480000/MIN_SPEED=648000/' \
+			-e 's/MAX_SPEED=1296000/MAX_SPEED=1200000/' /etc/default/cpufrequtils
+			;;
+	esac
+	echo "${MACHINE}" | tr '[:upper:]' '[:lower:]' | sed -e 's/+/plus/' \
+		-e 's/\ //g' >/etc/hostname
+	touch /var/run/reboot
+} # autodetect_h3
+
+#if [ "X${HARDWARE}" = "Xsun8i" ]; then
+#	autodetect_h3
+#fi
+
+do_expand_rootfs() {
+	device="/dev/"$(lsblk -idn -o NAME | grep mmcblk0)
+	PARTITIONS=$(($(fdisk -l $device | grep $device | wc -l)-1))
+	PARTSTART=$(parted $device unit s print -sm | tail -1 | cut -d: -f2 | sed 's/s//') # start of first partition
+	PARTEND=$(parted $device unit s print -sm | head -3 | tail -1 | cut -d: -f3 | sed 's/s//') # end of first partition
+	STARTFROM=$(($PARTEND+1))
+	[[ $PARTITIONS == 1 ]] && STARTFROM=$PARTSTART
+	((echo d; echo $PARTITIONS; echo n; echo p; echo ; echo $STARTFROM; echo ; echo w;) | fdisk $device) >/dev/null || true
+	s=0	
+	fsck -f $root_partition >/dev/null 2>&1 || true
+	partprobe $device >/dev/null 2>&1 || s=$?
+	resize2fs $root_partition >/dev/null 2>&1 || true
+	FREESIZE=$(df -hm / | awk '/\// {print $(NF-2)}')
+	if [[ "$DISTRIBUTION" == "wheezy" || "$s" != "0" || "$FREESIZE" -lt "152" ]]; then
+		touch /var/run/reboot
+		display_alert "Automatic reboot is needed. Please wait"
+		update-rc.d resize2fs defaults >/dev/null 2>&1 
+	fi
 return 0
 }
 
@@ -127,3 +167,4 @@ case "$1" in
 esac
 
 exit 0
+


### PR DESCRIPTION
armhwinfo OPi detection fix, firstrun cleanup/fix (192MB tempfs on boards with only 512 MB RAM) and preparation of autodetect_h3 and armbianmonitor (exporting variables)

autodetect_h3 is disabled by default (needs rearrangements in firstrun anyway since reboot is necessary) but tested on at least One/PC. Works there. But it still needs more testing so maybe preparing one image with it activated, building an image for the Plus and let users test? 2 drawbacks on boards != Plus: First start delayed due to missing network, kernel oops prior to reboot (without any noticeable consequences but this needs more testing)