### PR TITLE
Patch to support cheap / slow mmc card during kernel loading

### DIFF
--- a/patch/u-boot/u-boot-default/u-boot-02-support-cheap-mmc.patch
+++ b/patch/u-boot/u-boot-default/u-boot-02-support-cheap-mmc.patch
@@ -1,0 +1,12 @@
+diff -Nur a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+--- a/drivers/mmc/sunxi_mmc.c	2016-02-25 10:30:30.000000000 +0800
++++ b//drivers/mmc/sunxi_mmc.c	2016-02-25 10:46:07.723851155 +0800
+
+@@ -269,6 +269,6 @@	
+	unsigned i;
+	unsigned *buff = (unsigned int *)(reading ? data->dest : data->src);
+	unsigned byte_cnt = data->blocksize * data->blocks;
+-	unsigned timeout_msecs = byte_cnt >> 8;
++	unsigned timeout_msecs = byte_cnt >> 6;
+	if (timeout_msecs < 2000)
+		timeout_msecs = 2000;


### PR DESCRIPTION
U-boot will time out when loading kernel zImage file when we use slow mmc card. The patch will extend the timeout.