### PR TITLE
Mali r3p0 - libs for GLES (sunxi)

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -374,13 +374,13 @@ _EOF_
 
 	patch -f -s -p1 -r - <fix_build.patch >/dev/null
 	cd src
-	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- clean >/dev/null 2>&1
-	(make -j4 ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LINUX_SRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
+	make -s ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- clean >/dev/null 2>&1
+	(make -s -j4 ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- LINUX_SRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
 	cp os/linux/*.ko $DEST/cache/sdcard/lib/modules/$VER-$LINUXFAMILY/kernel/net/wireless/
 	mkdir -p $DEST/cache/sdcard/etc/Wireless/RT2870STA
 	cp RT2870STA.dat $DEST/cache/sdcard/etc/Wireless/RT2870STA/
 	depmod -b $DEST/cache/sdcard/ $VER-$LINUXFAMILY
-	make clean 1>&2 2>/dev/null
+	make -s clean 1>&2 2>/dev/null
 	cd ..
 	mkdir -p $DEST/cache/sdcard/usr/src/
 	cp -R src $DEST/cache/sdcard/usr/src/mt7601-3.0.0.4

--- a/config/sunxi-udev/50-cedar.rules
+++ b/config/sunxi-udev/50-cedar.rules
@@ -1,0 +1,1 @@
+KERNEL=="cedar_dev", MODE="0660", GROUP="video"

--- a/config/sunxi-udev/50-disp.rules
+++ b/config/sunxi-udev/50-disp.rules
@@ -1,0 +1,1 @@
+KERNEL=="disp", MODE="0660", GROUP="video"

--- a/config/sunxi-udev/50-ion.rules
+++ b/config/sunxi-udev/50-ion.rules
@@ -1,0 +1,1 @@
+KERNEL=="ion", MODE="0660", GROUP="video"

--- a/config/sunxi-udev/50-mali.rules
+++ b/config/sunxi-udev/50-mali.rules
@@ -1,0 +1,2 @@
+KERNEL=="mali", MODE="0660", GROUP="video"
+KERNEL=="ump", MODE="0660", GROUP="video"

--- a/desktop.sh
+++ b/desktop.sh
@@ -68,7 +68,7 @@ if [[ $LINUXFAMILY == *sun* && $BRANCH == "default" ]]; then
 	grep "CONFIG_MALI is not set" $SOURCES/$LINUXSOURCEDIR/.config 2>&1 >/dev/null
 	local error_num=$?
 	grep "CONFIG_UMP is not set" $SOURCES/$LINUXSOURCEDIR/.config 2>&1 >/dev/null
-	if [[ $? -eq 1 || $error_num -eq 1 ]]
+	if [[ $? -eq 1 && $error_num -eq 1 ]]
 	then
 	error_num=0
 	display_alert "Adding support for Mali - acceleration" "sunxi" "info"

--- a/desktop.sh
+++ b/desktop.sh
@@ -65,9 +65,59 @@ sed "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=true/g" -i $DEST/cache/sdcard/etc/defaul
 # Compile Turbo Frame buffer for sunxi
 if [[ $LINUXFAMILY == *sun* && $BRANCH == "default" ]]; then
 
+	grep "CONFIG_MALI is not set" $SOURCES/$LINUXSOURCEDIR/.config 2>&1 >/dev/null
+	local error_num=$?
+	grep "CONFIG_UMP is not set" $SOURCES/$LINUXSOURCEDIR/.config 2>&1 >/dev/null
+	if [[ $? -eq 1 || $error_num -eq 1 ]]
+	then
+	error_num=0
+	display_alert "Compiling support for Mali - acceleration" "sunxi" "info"
+	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libx11-dev libxext-dev libdrm-dev x11proto-dri2-dev libxfixes-dev 2>&1 >/dev/null"
+	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libdri2-dev 2>&1 >/dev/null"
+	if [ $? -gt 0 ]; then
+	git clone -q https://github.com/robclark/libdri2 $DEST/cache/sdcard/tmp/libdri2
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && ./autogen.sh 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && ./configure --prefix=/usr 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && make -s $CTHREADS && make -s install && ldconfig 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	fi
+	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1
+	else
+	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install git build-essential autoconf libtool 2>&1 >/dev/null"
+	git clone -q https://github.com/linux-sunxi/libump.git $DEST/cache/sdcard/tmp/libump
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && autoreconf -i 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && ./configure --prefix=/usr 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && make -s $CTHREADS && make -s install 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1
+	else
+	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install git build-essential autoconf automake xutils-dev 2>&1 >/dev/null"
+	git clone -q --recursive https://github.com/WhiteWind/sunxi-mali $DEST/cache/sdcard/tmp/sunxi-mali
+	sed 's/(prefix)lib\//(prefix)lib\/mali\//' -i $DEST/cache/sdcard/tmp/sunxi-mali/Makefile.setup
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && ABI=armhf VERSION=r3p0 EGL_TYPE=x11 make -s config 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && make -s -f Makefile.pc 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && make -s install 2>&1 >/dev/null"
+	error_num=$(($error_num+$?))
+	mkdir -p $DEST/cache/sdcard/usr/lib/pkgconfig
+	mv $DEST/cache/sdcard/usr/lib/mali/pkgconfig/* $DEST/cache/sdcard/usr/lib/pkgconfig/
+	mkdir -p $DEST/cache/sdcard/etc/udev/rules.d
+	cp $SRC/lib/config/sunxi-udev/* $DEST/cache/sdcard/etc/udev/rules.d/
+	sed 's/# Multiarch support/\/usr\/lib\/mali\n# Multiarch support/' -i $DEST/cache/sdcard/etc/ld.so.conf.d/arm-linux-gnueabihf.conf
+	chroot $DEST/cache/sdcard /bin/bash -c "ldconfig"
+	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1;fi
+	fi
+	fi
+	fi
+
 	display_alert "Compiling FB Turbo" "sunxi" "info"
 
-	local error_num=0
+	error_num=0
 	
 	# quemu bug walkaround
 	git clone -q https://github.com/ssvb/xf86-video-fbturbo.git $DEST/cache/sdcard/tmp/xf86-video-fbturbo

--- a/desktop.sh
+++ b/desktop.sh
@@ -75,10 +75,10 @@ if [[ $LINUXFAMILY == *sun* && $BRANCH == "default" ]]; then
 	git clone -q https://github.com/WereCatf/armbian-debs.git $DEST/cache/sdcard/tmp/armbian-debs
 	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libdri2-1 libdri2-dev 2>&1 >/dev/null"
 	if [ $? -gt 0 ]; then
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i libdri2_1.0-1_armhf.deb 2>&1 >/dev/null"
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i libdri2-1_1.0-1_armhf.deb 2>&1 >/dev/null"
 	error_num=$(($error_num+$?))
 	fi
-	if [ $error_num -gt 0 ]; then display_alert "Installation failed" "Mali - libdri2" "err"; exit 1
+	if [ $error_num -gt 0 ]; then display_alert "Installation failed" "Mali - libdri2-1" "err"; exit 1
 	else
 	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i libump_3.0-0sunxi1_armhf.deb libump-dev_3.0-0sunxi1_armhf.deb 2>&1 >/dev/null"
 	error_num=$(($error_num+$?))

--- a/desktop.sh
+++ b/desktop.sh
@@ -71,46 +71,23 @@ if [[ $LINUXFAMILY == *sun* && $BRANCH == "default" ]]; then
 	if [[ $? -eq 1 || $error_num -eq 1 ]]
 	then
 	error_num=0
-	display_alert "Compiling support for Mali - acceleration" "sunxi" "info"
-	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libx11-dev libxext-dev libdrm-dev x11proto-dri2-dev libxfixes-dev 2>&1 >/dev/null"
-	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libdri2-dev 2>&1 >/dev/null"
+	display_alert "Adding support for Mali - acceleration" "sunxi" "info"
+	git clone -q https://github.com/WereCatf/armbian-debs.git $DEST/cache/sdcard/tmp/armbian-debs
+	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install libdri2-1 libdri2-dev 2>&1 >/dev/null"
 	if [ $? -gt 0 ]; then
-	git clone -q https://github.com/robclark/libdri2 $DEST/cache/sdcard/tmp/libdri2
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && ./autogen.sh 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && ./configure --prefix=/usr 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libdri2 && make -s $CTHREADS && make -s install && ldconfig 2>&1 >/dev/null"
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i libdri2_1.0-1_armhf.deb 2>&1 >/dev/null"
 	error_num=$(($error_num+$?))
 	fi
-	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1
+	if [ $error_num -gt 0 ]; then display_alert "Installation failed" "Mali - libdri2" "err"; exit 1
 	else
-	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install git build-essential autoconf libtool 2>&1 >/dev/null"
-	git clone -q https://github.com/linux-sunxi/libump.git $DEST/cache/sdcard/tmp/libump
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && autoreconf -i 2>&1 >/dev/null"
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i libump_3.0-0sunxi1_armhf.deb libump-dev_3.0-0sunxi1_armhf.deb 2>&1 >/dev/null"
 	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && ./configure --prefix=/usr 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/libump && make -s $CTHREADS && make -s install 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1
+	if [ $error_num -gt 0 ]; then display_alert "Installation failed" "Mali - libump" "err"; exit 1
 	else
-	chroot $DEST/cache/sdcard /bin/bash -c "apt-get -y install git build-essential autoconf automake xutils-dev 2>&1 >/dev/null"
-	git clone -q --recursive https://github.com/WhiteWind/sunxi-mali $DEST/cache/sdcard/tmp/sunxi-mali
-	sed 's/(prefix)lib\//(prefix)lib\/mali\//' -i $DEST/cache/sdcard/tmp/sunxi-mali/Makefile.setup
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && ABI=armhf VERSION=r3p0 EGL_TYPE=x11 make -s config 2>&1 >/dev/null"
+	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/armbian-debs && dpkg -i sunxi-mali-r3p0_4.0.0.0_armhf.deb 2>&1 >/dev/null"
 	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && make -s -f Makefile.pc 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	chroot $DEST/cache/sdcard /bin/bash -c "cd /tmp/sunxi-mali && make -s install 2>&1 >/dev/null"
-	error_num=$(($error_num+$?))
-	mkdir -p $DEST/cache/sdcard/usr/lib/pkgconfig
-	mv $DEST/cache/sdcard/usr/lib/mali/pkgconfig/* $DEST/cache/sdcard/usr/lib/pkgconfig/
-	mkdir -p $DEST/cache/sdcard/etc/udev/rules.d
-	cp $SRC/lib/config/sunxi-udev/* $DEST/cache/sdcard/etc/udev/rules.d/
-	sed 's/# Multiarch support/\/usr\/lib\/mali\n# Multiarch support/' -i $DEST/cache/sdcard/etc/ld.so.conf.d/arm-linux-gnueabihf.conf
 	chroot $DEST/cache/sdcard /bin/bash -c "ldconfig"
-	if [ $error_num -gt 0 ]; then display_alert "Compiling failed" "Mali - acceleration" "err"; exit 1;fi
+	if [ $error_num -gt 0 ]; then display_alert "Installation failed" "Mali r3p0" "err"; exit 1;fi
 	fi
 	fi
 	fi


### PR DESCRIPTION
This pull-request installs support for H/W-accelerated GLES if the kernel has been compiled with mali and ump and the image is built with desktop.

I built libdri2, libump and sunxi-mali into debs (there may be some issues there as I have never played around with building deb-files before, but they do seem to work fine) so there's no need to build them every single time an image is built, and this way it'll be easier to distribute updates to them if there's a need for that and you ever set up an Armbian - repo for updates.

I modified sunxi-mali to install the mali - libraries to /usr/lib/mali instead of /usr/lib and added 01-mali.conf pointing to it in /etc/ld.so.conf.d so that the mali EGL/GLES libs are picked over the mesa - ones, all without having to move the mesa - provided ones anywhere or removing them.

Tested with Wheezy, Jessie and Trusty, WorksForMe(TM).