### PR TITLE
Spruce h3disp up a bit

### DIFF
--- a/scripts/h3disp
+++ b/scripts/h3disp
@@ -25,6 +25,10 @@
 #
 # CHANGES:
 #
+# v0.3: Added the ability to set the colour-range HDMI-output and spruced the
+#       output of h3disp in general with a splash of colour. Also, don't spit
+#       out so much text by default.
+#
 # v0.2: Added non-interactive mode. You can provide one or two arguments on
 #       the command line, eg. 'h3disp -m 1080p60 -d' (1920x1080@60Hz DVI) or 
 #       'h3disp -m 720i' (1280x720@30Hz HDMI). Complete list of modes via
@@ -72,6 +76,17 @@ Main() {
 		:
 	else
 		ParseOptions "$@"
+		if [ -v ColourRange ]; then
+			re='^[0-9]+$'
+			if ! [[ ${ColourRange} =~ ${re} ]] ; then
+				echo "$0: Invalid colour-range specified, only values 0-2 are supported for now!"
+				exit 1
+				fi
+			if [[ ${ColourRange} -lt 0 || ${ColourRange} -gt 2 ]] ; then
+				echo "$0: Invalid colour-range specified, only values 0-2 are supported for now!"
+				exit 1
+			fi
+		fi
 		case ${VideoMode} in
 			0|480i) # res
 				HDMIMode=0
@@ -134,8 +149,13 @@ Main() {
 } # Main
 
 ParseOptions() {
-	while getopts 'hvVdDm:M:' c ; do
+	while getopts 'hHvVdDm:M:c:C:' c ; do
 	case ${c} in
+		H)
+			export FullUsage=TRUE
+			DisplayUsage
+			exit 0
+			;;
 		h)
 			DisplayUsage
 			exit 0
@@ -158,33 +178,64 @@ ParseOptions() {
 			# The HDMI mode in question
 			export VideoMode=${OPTARG}
 			;;
+		c|C)
+			# The colour-range in question
+			export ColourRange=${OPTARG}
+			;;
 	esac
 	done
 } # ParseOptions
 
 DisplayUsage() {
-	echo -e "Usage: ${0##*/} -m [video mode] [-d]\n"
-	echo -e "############################################################################\n"
-	echo "Detailed Description:"
+	# check if stdout is a terminal...
+	if test -t 1; then
+		# see if it supports colors...
+		ncolors=$(tput colors)
+		if test -n "$ncolors" && test $ncolors -ge 8; then
+			BOLD="$(tput bold)"
+			NC='\033[0m' # No Color
+			LGREEN='\033[1;32m'
+		fi
+	fi
+	echo -e "Usage: ${BOLD}${0##*/} [-h/-H] -m [video mode] [-d] [-c [0-2]]${NC}\n"
+	echo -e "############################################################################"
+	if [ ${FullUsage} ]; then
+	echo -e "\nDetailed Description:"
 	grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
-	echo -e "\n Short summary: This is a tool to set the display resolution of your Orange"
+	fi
+	echo -e "\n This is a tool to set the display resolution of your Orange"
 	echo -e " Pi by patching script.bin.\n\n In case you use an HDMI-to-DVI converter\c"
-	echo -e " please use the -d switch.\n\n The resolution can be set using the -m switch.\c"
+	echo -e " please use the ${LGREEN}-d${NC} switch.\n\n The resolution can be set using the ${LGREEN}-m${NC} switch.\c"
 	echo -e " The following resolutions\n are currently supported:\n"
 	ShowVideoModes
+	echo -e " You can also specify the colour-range for your HDMI-display with the ${LGREEN}-c${NC} switch."
+	echo -e "\n The following values for ${LGREEN}-c${NC} are currently supported:\n"
+	echo -e "    ${BOLD}0${NC} -- RGB range 16-255 (Default, use \"${LGREEN}-c 0${NC}\")"
+	echo -e "    ${BOLD}1${NC} -- RGB range 0-255 (Full range, use \"${LGREEN}-c 1${NC}\")"
+	echo -e "    ${BOLD}2${NC} -- RGB range 16-235 (Limited video, \"${LGREEN}-c 2${NC}\")\n"
 	echo -e "############################################################################\n"
 } # DisplayUsage
 
 ShowVideoModes() {
+	# check if stdout is a terminal...
+	if test -t 1; then
+		# see if it supports colors...
+		ncolors=$(tput colors)
+		if test -n "$ncolors" && test $ncolors -ge 8; then
+			BOLD="$(tput bold)"
+			NC='\033[0m' # No Color
+			LGREEN='\033[1;32m'
+		fi
+	fi
 	OIFS=${IFS}
 	IFS="|"
 	awk -F" " '/ # res/ {print $1}' <"${0}" | tr -d ')' | grep -v 'awk' | while read ; do
 		set ${REPLY}
-		echo -e "    ${2}\tuse \"-m ${2}\" or \"-m ${1}\""
+		echo -e "    ${BOLD}${2}${NC}\tuse \"${LGREEN}-m ${2}${NC}\" or \"${LGREEN}-m ${1}${NC}\""
 	done		
 	IFS=${OIFS}
-	echo -e "\n Two examples:\n\n    ${0##*/} -m 1080p60 -d' (1920x1080@60Hz DVI)"
-	echo -e "    ${0##*/} -m 720i' (1280x720@30Hz HDMI)\n"
+	echo -e "\n Two examples:\n\n    '${BOLD}${0##*/}${NC} ${LGREEN}-m 1080p60 -d${NC}' (1920x1080@60Hz DVI)"
+	echo -e "    '${BOLD}${0##*/}${NC} ${LGREEN}-m 720i${NC}' (1280x720@30Hz HDMI)\n"
 } # ShowVideoModes
 
 PatchScriptBin() {	
@@ -217,7 +268,10 @@ PatchScriptBin() {
 	MyTmpFile="$(mktemp /tmp/${0##*/}.XXXXXX)"
 
 	# convert script.bin to temporary fex file	
-	bin2fex <"${ScriptBin}" 2>/dev/null | grep -v "^screen0_output" \
+	local filter="^screen0_output"
+	if [ -v ColourRange ]; then
+		filter="^screen0_out"; fi
+	bin2fex <"${ScriptBin}" 2>/dev/null | grep -v ${filter} \
 		| grep -v "^screen1_output" | grep -v "hdcp_enable" \
 		| grep -v "hdmi_cts_compatibility" >"${MyTmpFile}"
 	if [ $? -ne 0 ]; then
@@ -229,6 +283,10 @@ PatchScriptBin() {
 	cp -p "${ScriptBin}" "${Path2ScriptBin}/script.bin.bak"
 
 	sed -i "/\[disp_init\]/a screen0_output_type = 3\nscreen0_output_mode = $1\nscreen1_output_type = 3\nscreen1_output_mode = $1" "${MyTmpFile}"
+
+	if [ -v ColourRange ]; then
+		sed -i "/\[disp_init\]/a screen0_out_color_range = ${ColourRange}" "${MyTmpFile}"
+	fi
 	
 	if [ "X$2" = "XTRUE" ]; then
 		# add entries necessary for HDMI-to-DVI adapters	
@@ -239,9 +297,11 @@ PatchScriptBin() {
 	fex2bin "${MyTmpFile}" "${ScriptBin}" 2>/dev/null
 	if [ $? -ne 0 ]; then
 	        mv "${Path2ScriptBin}/script.bin.bak" "${ScriptBin}"
-	        echo -e "Aborted\nWriting script.bin went wrong. Nothing changed" >&2
+	        echo -e "Aborted\nWriting script.bin went wrong. Nothing changed." >&2
+	        echo -e "You may look at ${MyTmpFile} to see if there is an error there." >&2
 	        logger "Writing script.bin went wrong. Nothing changed"
 	        exit 1
+	else rm "${MyTmpFile}"
 	fi
 } # PatchScriptBin
 


### PR DESCRIPTION
Add the ability to specify HDMI colour-range, don't spit out changelogs and all that by default since those are not useful for most users (use -H instead of -h to see those), and use colour to make the output a bit more readable if the terminal is capable of colour ( https://dl.dropboxusercontent.com/u/11811685/h3disp.png ) -- does not output colour when redirected to a file, for example.