### PR TITLE
Fixed user creation and GUI mode, prevented manual sunxi-tools build

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -166,13 +166,11 @@ compile_sunxi_tools (){
 	rm -f sunxi-fexc sunxi-nand-part
 	make -s >/dev/null 2>&1
 	cp fex2bin bin2fex /usr/local/bin/
-	make -s clean >/dev/null 2>&1
-	rm -f sunxi-fexc sunxi-nand-part meminfo sunxi-fel sunxi-pio 2>/dev/null
-	make $CTHREADS 'sunxi-nand-part' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
-	make $CTHREADS 'sunxi-fexc' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
-	make $CTHREADS 'sunxi-fel' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
-	make $CTHREADS 'sunxi-pio' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
-	make $CTHREADS 'meminfo' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
+	# make -s clean >/dev/null 2>&1
+	# rm -f sunxi-fexc sunxi-nand-part meminfo sunxi-fel sunxi-pio 2>/dev/null
+	# make $CTHREADS 'sunxi-nand-part' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
+	# make $CTHREADS 'sunxi-fexc' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
+	# make $CTHREADS 'meminfo' CC=arm-linux-gnueabihf-gcc >> $DEST/debug/install.log 2>&1
 
 }
 

--- a/desktop.sh
+++ b/desktop.sh
@@ -24,7 +24,7 @@ if [[ $RELEASE == "wheezy" ]]; then
 	# copy wallpapers and default desktop settings
 	d=$DEST/cache/sdcard/usr/share/xfce4/backdrops/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
-	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/wheezy-desktop.tgz -C /root/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/wheezy-desktop.tgz -C /etc/skel/"
 fi
 
 # Debian Jessie
@@ -32,7 +32,7 @@ if [[ $RELEASE == "jessie" ]]; then
 	# copy wallpapers and default desktop settings
 	d=$DEST/cache/sdcard/usr/share/backgrounds/xfce/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
-	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /root/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /etc/skel/"
 fi
 
 # Ubuntu trusty
@@ -40,7 +40,7 @@ if [[ $RELEASE == "trusty" ]]; then
 	# copy wallpapers and default desktop settings
 	d=$DEST/cache/sdcard/usr/share/backgrounds/xfce/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
-	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /root/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /etc/skel/"
 fi
 
 # Install custom icons and theme
@@ -59,8 +59,8 @@ if [[ $BOARD != "udoo" ]]; then
 	echo "wireless_interface = wlan0" >> $DEST/cache/sdcard/etc/wicd/manager-settings.conf
 fi
 
-# Enable desktop moode autostart without password
-sed "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=true/g" -i $DEST/cache/sdcard/etc/default/nodm
+# Disable desktop mode autostart for now to enforce creation of normal user account
+sed "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=false/g" -i $DEST/cache/sdcard/etc/default/nodm
  
 # Compile Turbo Frame buffer for sunxi
 if [[ $LINUXFAMILY == *sun* && $BRANCH == "default" ]]; then

--- a/documentation/H3_mini_faq.md
+++ b/documentation/H3_mini_faq.md
@@ -12,13 +12,15 @@ Armbian supports starting with release 5.04 all available H3 based Orange Pi boa
 - USB-to-SATA bridge on the Orange Pi Plus works
 - stability problems on Orange Pi One fixed (due to undervoltage based on wrong fex settings)
 - problems with 2 USB ports on the PC fixed (wrong kernel config)
+- Mali400MP acceleration (EGL/GLES) works now
+- suspend to RAM and resume by power button works now (consumption less than 0.4W without peripherals)
 - already useable as stable headless/server board
 
 ***Important to know***
 
 - [User documentation](http://www.armbian.com/documentation/)
 - [Geek documentation](http://www.armbian.com/using-armbian-tools/)
-- 1st boot takes longer (up to 5 minutes). Please do not interrupt while the red LED is blinking, the board reboots automatically one time
+- 1st boot takes longer (up to 5 minutes). Please do not interrupt while the red LED is blinking, the board reboots automatically one time and the green LED starts to blink when ready
 - CPU frequency settings are 648-1200 MHz on OPi One/Lite and 480-1296 MHz on the other boards (cpufreq governor is _interactive_ therefore the board only increases CPU speed and consumption when needed)
 - These are still test images regarding everything beyond headless/server usage
 - In case you experience instabilities, think about installing [RPi-Monitor for H3](http://forum.armbian.com/index.php/topic/617-wip-orange-pi-one-support-for-the-upcoming-orange-pi-one/?p=5076) to get an idea whether you suffer from overheating

--- a/documentation/H3_mini_faq.md
+++ b/documentation/H3_mini_faq.md
@@ -7,13 +7,14 @@ Armbian supports starting with release 5.04 all available H3 based Orange Pi boa
 - HDMI/DVI works (bug in boot.cmd settings)
 - Reboot issues fixed (bug in fex settings)
 - 1-Wire useable (we chose to stay compatible to loboris' images so the data pin is 37 by default. You're able to change this in the [fex file](https://github.com/igorpecovnik/lib/blob/6d995e31583e5361c758b401ea44634d406ac3da/config/orangepiplus.fex#L1284-L1286))
-- changing display resolution and choosing between HDMI and DVI now possible with the included _h3disp_ tool (should also work in the [stand-alone version](http://forum.armbian.com/index.php/topic/617-wip-orange-pi-one-support-for-the-upcoming-orange-pi-one/?p=5480) with Debian based OS images from loboris/Xunlong)
+- changing display resolution and choosing between HDMI and DVI now possible with the included _h3disp_ tool (should also work in the [stand-alone version](http://forum.armbian.com/index.php/topic/617-wip-orange-pi-one-support-for-the-upcoming-orange-pi-one/?p=5480) with Debian based OS images from loboris/Xunlong). Use _sudo h3disp_ in a terminal to get the idea.
 - Ethernet issues fixed (combination of kernel and fex fixes)
 - USB-to-SATA bridge on the Orange Pi Plus works
 - stability problems on Orange Pi One fixed (due to undervoltage based on wrong fex settings)
 - problems with 2 USB ports on the PC fixed (wrong kernel config)
 - Mali400MP acceleration (EGL/GLES) works now
 - suspend to RAM and resume by power button works now (consumption less than 0.4W without peripherals)
+- Enforce user account creation before starting the GUI
 - already useable as stable headless/server board
 
 ***Important to know***
@@ -25,12 +26,12 @@ Armbian supports starting with release 5.04 all available H3 based Orange Pi boa
 - These are still test images regarding everything beyond headless/server usage
 - In case you experience instabilities, think about installing [RPi-Monitor for H3](http://forum.armbian.com/index.php/topic/617-wip-orange-pi-one-support-for-the-upcoming-orange-pi-one/?p=5076) to get an idea whether you suffer from overheating
 
-***Areas that need testing***
+***Areas that need testing/feedback***
 
 - SPI
 - I2C
 - GPIO in general
-- GPU acceleration (needs _boot.cmd_ adjustments and at least _mali_ module loaded)
+- GPU acceleration
 - Wi-Fi on OPi Plus, Plus 2 and 2
 - USB wireless dongles
 
@@ -49,4 +50,4 @@ Armbian supports starting with release 5.04 all available H3 based Orange Pi boa
 
 Mainlining effort for H3 and Orange Pi's is progressing nicely but since Ethernet support still isn't ready we currently do not provide OS images with vanilla kernel (for the impatient: early patches [here](http://sunxi.montjoie.ovh/patchs_current/) and discussion [there](https://groups.google.com/forum/#!topic/linux-sunxi/ZrVjF74mliY))
 
-But since we collected a bunch of [necessary H3 patches](https://github.com/igorpecovnik/lib/commit/79c7662a491b46caf07f05880403903dccc33cd1) you're already able to build your own 4.4.x image at this time. Just choose Orange Pi Plus as target or Orange Pi H3 for PC/One/2/Lite. But please remember that you end up with a rather limited image where just SMP, UART and USB is working. The good news: With a GbE Ethernet dongle network gets faster on all Oranges except the Plus and since you can make use of [USB Attached SCSI](http://linux-sunxi.org/USB/UAS) with mainline kernel USB performance also increases.
+But since we collected a bunch of [necessary H3 patches](https://github.com/igorpecovnik/lib/commit/79c7662a491b46caf07f05880403903dccc33cd1) you're already able to build your own 4.4.x image at this time. Just choose Orange Pi Plus as target or Orange Pi H3 for PC/One/2/Lite. But please remember that you end up with a rather limited image where just SMP, UART and USB is working. The good news: With a GbE Ethernet dongle network gets faster on all Oranges except the Plus and since you can make use of [USB Attached SCSI](http://linux-sunxi.org/USB/UAS) with mainline kernel USB performance also increases when your drive enclosure supports UAS.

--- a/makeboarddeb.sh
+++ b/makeboarddeb.sh
@@ -96,14 +96,14 @@ create_board_package (){
 
 	if [[ $LINUXCONFIG == *sun* ]] ; then
 
-		# add sunxi tools	
-		cp $SOURCES/$MISC1_DIR/meminfo $destination/usr/local/bin/meminfo
-		cp $SOURCES/$MISC1_DIR/sunxi-nand-part $destination/usr/local/bin/nand-part
-		cp $SOURCES/$MISC1_DIR/sunxi-fexc $destination/usr/local/bin/sunxi-fexc
-		cp $SOURCES/$MISC1_DIR/sunxi-fel $destination/usr/local/bin/sunxi-fel
-		cp $SOURCES/$MISC1_DIR/sunxi-pio $destination/usr/local/bin/sunxi-pio
-		ln -s $destination/usr/sbin/sunxi-fexc $destination/usr/sbin/fex2bin
-		ln -s $destination/usr/sbin/sunxi-fexc $destination/usr/sbin/bin2fex
+		# add sunxi tools -- not necessary any more since .deb gets installed
+		# cp $SOURCES/$MISC1_DIR/meminfo $destination/usr/local/bin/meminfo
+		# cp $SOURCES/$MISC1_DIR/sunxi-nand-part $destination/usr/local/bin/nand-part
+		# cp $SOURCES/$MISC1_DIR/sunxi-fexc $destination/usr/local/bin/sunxi-fexc
+		# cp $SOURCES/$MISC1_DIR/sunxi-fel $destination/usr/local/bin/sunxi-fel
+		# cp $SOURCES/$MISC1_DIR/sunxi-pio $destination/usr/local/bin/sunxi-pio
+		# ln -s $destination/usr/sbin/sunxi-fexc $destination/usr/sbin/fex2bin
+		# ln -s $destination/usr/sbin/sunxi-fexc $destination/usr/sbin/bin2fex
 		if [ "$BRANCH" != "next" ]; then
 			# add soc temperature app
 			arm-linux-gnueabihf-gcc $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/local/bin/sunxi_tp_temp

--- a/scripts/check_first_login.sh
+++ b/scripts/check_first_login.sh
@@ -18,10 +18,9 @@ if [ "$-" != "${-#*i}" ]; then
 		if [ -f /etc/init.d/nodm ] ; then 
 			sed -i "s/NODM_USER=\(.*\)/NODM_USER=${RealUserName}/" /etc/default/nodm
 			sed -i "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=true/g" /etc/default/nodm
-			# update-rc.d nodm enable >/dev/null 2>&1
-			echo -e "\n\e[1m\e[39mOne more reboot necessary...\x1B[0m\n"
+			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
 			sleep 1
-			reboot
+			service nodm start
 		fi
 	fi
 fi

--- a/scripts/check_first_login.sh
+++ b/scripts/check_first_login.sh
@@ -11,12 +11,16 @@ if [ "$-" != "${-#*i}" ]; then
 			usermod -aG ${additionalgroup} ${RealUserName}
 		done
 		rm -f "$HOME/.not_logged_in_yet"
-		echo -e "\nYour accout ${RealUserName} has been created and is sudo enabled.\n"
+		RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" </etc/passwd | cut -d',' -f1)"
+		echo -e "\nDear ${RealName}, your account ${RealUserName} has been created and is sudo enabled."
+		echo -e "Please use this account for your daily work from now on.\n"
 		# check whether desktop environment has to be considered
 		if [ -f /etc/init.d/nodm ] ; then 
-			sed -i "s/NODM_USER=root/NODM_USER=${RealUserName}/" /etc/default/nodm
-			update-rc.d nodm enable >/dev/null 2>&1
-			echo -e "\n\e[1m\e[39mReboot necessary...\x1B[0m\n"
+			sed -i "s/NODM_USER=\(.*\)/NODM_USER=${RealUserName}/" /etc/default/nodm
+			sed -i "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=true/g" /etc/default/nodm
+			# update-rc.d nodm enable >/dev/null 2>&1
+			echo -e "\n\e[1m\e[39mOne more reboot necessary...\x1B[0m\n"
+			sleep 1
 			reboot
 		fi
 	fi


### PR DESCRIPTION
Works now as it should. After 1st boot no GUI, red LED starts to blink, then automatic reboot. Then still no GUI, user has to login, change root pwd and has then to create a user account. In case it's a desktop image /etc/default/nodm will be altered and the nodm service started. The GUI comes up without authentication. The two links are on the desktop of the user in question.

Authentication is only needed for things like shutdown/suspend. Maybe this can be tweaked also? 

But IMO this was the biggest showstopper prior to releasing 5.04 for our new and somewhat different audience ;)