### PR TITLE
Build a10disp for sun8i target also, improve 1st login on H3 devices

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -140,7 +140,6 @@ END
 	rm -rf $CHOOSEN_UBOOT
 	CHOOSEN_UBOOT=$CHOOSEN_UBOOT".deb"
 
-
 	FILESIZE=$(wc -c $DEST/debs/$CHOOSEN_UBOOT | cut -f 1 -d ' ')
 
 	if [[ $FILESIZE -lt 50000 ]]; then
@@ -153,7 +152,6 @@ END
 		display_alert "Source file $1 does not exists. Check fetch_from_github configuration." "" "err"
 fi
 }
-
 
 compile_sunxi_tools (){
 #---------------------------------------------------------------------------------------------------------------------------------
@@ -302,7 +300,6 @@ cp $SOURCES/usb-redirector-linux-arm-eabi/files/rc.usbsrvd $DEST/cache/sdcard/et
 # not started by default ----- update.rc rc.usbsrvd defaults
 # chroot $DEST/cache/sdcard /bin/bash -c "update-rc.d rc.usbsrvd defaults"
 
-
 # some aditional stuff. Some driver as example
 if [[ -n "$MISC3_DIR" ]]; then
 	display_alert "Installing external applications" "RT8192 driver" "info"
@@ -316,10 +313,15 @@ if [[ -n "$MISC3_DIR" ]]; then
 fi
 
 # MISC4 = NOTRO DRIVERS / special handling
-# MISC5 = sunxu display control
-if [[ -n "$MISC5_DIR" && $BRANCH != "next" && $LINUXSOURCEDIR == *sunxi* ]]; then
+
+# MISC5 = sunxi display control
+if [[ -n "$MISC5_DIR" && $BRANCH != "next" && $LINUXSOURCEDIR == *sunxi* -o $LINUXSOURCEDIR == *sun8i* ]]; then
 	cd $SOURCES/$MISC5_DIR
-	cp $SOURCES/$LINUXSOURCEDIR/include/video/sunxi_disp_ioctl.h .
+	if [ -f "$SOURCES/$LINUXSOURCEDIR/include/video/sunxi_disp_ioctl.h" ]; then
+		cp "$SOURCES/$LINUXSOURCEDIR/include/video/sunxi_disp_ioctl.h" .
+	else
+		wget -q "https://raw.githubusercontent.com/linux-sunxi/linux-sunxi/sunxi-3.4/include/video/sunxi_disp_ioctl.h"
+	fi
 	make clean >/dev/null 2>&1
 	(make ARCH=arm CC=arm-linux-gnueabihf-gcc KSRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
 	install -m 755 a10disp $DEST/cache/sdcard/usr/local/bin
@@ -394,8 +396,6 @@ if [ "$BOARD" = "orangepiplus" -o "$BOARD" = "orangepih3" ]; then
 fi
 }
 
-
-
 shrinking_raw_image (){ # Parameter: RAW image with full path
 #---------------------------------------------------------------------------------------------------------------------------------
 # Shrink partition and image to real size with a place for 128Mb swap space
@@ -448,7 +448,6 @@ losetup -d $LOOP
 echo "NEWSIZE $NEWSIZE STARTFROM $STARTFROM TRUNCATE $TRUNCATE" >> $DEST/debug/install.log 
 }
 
-
 closing_image (){
 #--------------------------------------------------------------------------------------------------------------------------------
 # Closing image and clean-up 									            
@@ -478,7 +477,6 @@ if [ "$BUILD_DESKTOP" = "yes" ]; then
 VERSION=$VERSION"_desktop"
 fi
  
-
 # kill process inside
 KILLPROC=$(ps -uax | pgrep ntpd |        tail -1); if [ -n "$KILLPROC" ]; then kill -9 $KILLPROC; fi  
 KILLPROC=$(ps -uax | pgrep dbus-daemon | tail -1); if [ -n "$KILLPROC" ]; then kill -9 $KILLPROC; fi  

--- a/desktop.sh
+++ b/desktop.sh
@@ -25,6 +25,7 @@ if [[ $RELEASE == "wheezy" ]]; then
 	d=$DEST/cache/sdcard/usr/share/xfce4/backdrops/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/wheezy-desktop.tgz -C /etc/skel/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/wheezy-desktop.tgz -C /root/"
 fi
 
 # Debian Jessie
@@ -33,6 +34,7 @@ if [[ $RELEASE == "jessie" ]]; then
 	d=$DEST/cache/sdcard/usr/share/backgrounds/xfce/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /etc/skel/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /root/"
 fi
 
 # Ubuntu trusty
@@ -41,6 +43,7 @@ if [[ $RELEASE == "trusty" ]]; then
 	d=$DEST/cache/sdcard/usr/share/backgrounds/xfce/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /etc/skel/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /etc/root/"
 fi
 
 # Install custom icons and theme

--- a/desktop.sh
+++ b/desktop.sh
@@ -43,7 +43,7 @@ if [[ $RELEASE == "trusty" ]]; then
 	d=$DEST/cache/sdcard/usr/share/backgrounds/xfce/
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /etc/skel/"
-	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /etc/root/"
+	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/trusty-desktop.tgz -C /root/"
 fi
 
 # Install custom icons and theme

--- a/scripts/check_first_login.sh
+++ b/scripts/check_first_login.sh
@@ -14,13 +14,28 @@ if [ "$-" != "${-#*i}" ]; then
 		RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" </etc/passwd | cut -d',' -f1)"
 		echo -e "\nDear ${RealName}, your account ${RealUserName} has been created and is sudo enabled."
 		echo -e "Please use this account for your daily work from now on.\n"
+
+		# check for H3 since this is FAQ stuff, add other boards later
+		HARDWARE=$(awk '/Hardware/ {print $3}' </proc/cpuinfo)
+		if [ "X${HARDWARE}" = "Xsun8i" ]; then
+			setterm -default
+			echo -e "\nYour display settings are currently 720p (1280x720). To change this use the"
+			echo -e "h3disp utility. Do you want to change display settings now? [yN] \c"
+			read -n1 ConfigureDisplay
+			if [ "X${ConfigureDisplay}" = "Xy" -o "X${ConfigureDisplay}" = "XY" ]; then
+				echo -e "\n" ; /usr/local/bin/h3disp
+			fi
+		fi
+
 		# check whether desktop environment has to be considered
 		if [ -f /etc/init.d/nodm ] ; then 
 			sed -i "s/NODM_USER=\(.*\)/NODM_USER=${RealUserName}/" /etc/default/nodm
 			sed -i "s/NODM_ENABLED=\(.*\)/NODM_ENABLED=true/g" /etc/default/nodm
-			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
-			sleep 1
-			service nodm start
+			if [ "X${ConfigureDisplay}" != "Xy" -a "X${ConfigureDisplay}" != "XY" ]; then
+				echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
+				sleep 3
+				service nodm start
+			fi
 		fi
 	fi
 fi


### PR DESCRIPTION
At the moment a10disp isn't useful with our 3.4.x sun8i kernel but if/when sun7i display stuff will be ported by whoever we could call it from h3disp to prevent reboots to change display resolution. Also I thought it would be better to point directly to _h3disp_ at 1st login for new H3 Armbian users.