### PR TITLE
Prepare support for Banana Pi M2+ and board/config mismatch in armhwinfo

### DIFF
--- a/config/bananapim2plus.fex
+++ b/config/bananapim2plus.fex
@@ -1,0 +1,1281 @@
+;Placeholder for Banana Pi M2 -- the name of the fex is important yet, nothing else
+
+[product]
+version = "100"
+machine = "bananapim2-plus"
+
+;---------------------------------------------------------------------------------------------------------
+; eraseflag - 1 erase data partition, 0 - do not erase data partition
+; next_work - action after burn, 0x0 by config, 0x1, normal, 0x2 reboot 0x3 ,shutdown,0x4 reupdate ,0x5 boot
+;---------------------------------------------------------------------------------------------------------
+[platform]
+debug_mode = 1
+eraseflag   = 1
+next_work = 2
+
+;----------------------------------------------------------------------------------
+;[target]  system bootup configuration
+;boot_clock	= CPU boot frequency, Unit: MHz
+;storage_type	= boot medium, 0-nand, 1-card0, 2-card2, -1(defualt)auto scan
+;----------------------------------------------------------------------------------
+[target]
+boot_clock   	= 1008
+storage_type    = -1
+
+;---------------------------------------------------------------------------------
+; uboot key detect enable
+; 当keyen_flag = 1 时，支持按键检测
+; 当keyen_flag = 0 时，不支持
+;---------------------------------------------------------------------------------
+[key_detect_en]
+keyen_flag = 0
+
+;---------------------------------------------------------------------------------
+;"一键进烧写功能"的按键值配置，按住位于min~max范围内的按键都可以强制进烧写
+; fel_key_max用于配置按键的最大键值
+; fel_key_min用于配置按键的最小键值
+;---------------------------------------------------------------------------------
+[fel_key]
+fel_key_max            =07
+fel_key_min            =02
+
+;----------------------------------------------------------------------------------
+;card boot
+;logical_start用于配置启动卡上mbr的位置相对于SD卡sector 0的偏移，单位为sector(512byte)
+;sprite_gpio0用于配置卡量产时指示灯所用的gpio
+;----------------------------------------------------------------------------------
+;-------------------------------------------------------------------------------
+;	sprite_work_delay	:
+;	 sprite_err_delay	:
+;		 sprite_gpio0	：	卡量产、一键recovery状态指示灯
+;			next_work	： 卡量产完成，工作状态(默认关机)
+;-------------------------------------------------------------------------------
+[card_boot]
+logical_start   = 40960
+sprite_work_delay	= 500
+sprite_err_delay	= 200
+sprite_gpio0    = port:PA15<1><default><default><default>
+next_work       = 3
+
+;---------------------------------------------------------------------------------
+; used       : 1: used this config, 0: not
+; start_type : 1: start system directly when power supply, 0: wait IR/KEY to power on
+; irkey_used : 1: ir key used, 0: not
+; pmukey_used: 1: physical button used, 0: not
+; led_power  : 1: light, 0: off
+; led_state  : 1: light, 0: off
+;---------------------------------------------------------------------------------
+[box_start_os]
+used = 1
+start_type = 1
+irkey_used = 1
+pmukey_used = 1
+pmukey_num = 3
+led_power = 0
+led_state = 0
+
+;-------------------------------------------------------------------------------
+; 	boot阶段上电初始化GPIO
+;		used		:模块使能端     置1：开启模块   置0：关闭模块
+;		gpiox ：上电初始化gpio （名称自定，但不能重复，并且GPIO允许可以多个）
+;		PH06  : 系统显示LED GPIO
+;-------------------------------------------------------------------------------
+[boot_init_gpio]
+used	=	1
+gpio0	=  port:PA15<1><default><default><1>
+gpio1	=  port:PG11<1><default><default><1>
+
+;----------------------------------------------------------------------------------
+;	used: 模块使能端     1：开启模块   0：关闭模块
+;	mode: 模式选择		 1：一键进入OTA升级		2：一键恢复（通过sysrecovery分区来恢复）  其他值：无效
+;	recovery_key ： 按键配置  （例如：recovery_key= port:PH16<0><default>）
+;----------------------------------------------------------------------------------
+[recovery_para]
+used =	1
+mode =	2
+recovery_key = port:PL04<0><default><default><default>
+
+
+;---------------------------------------------------------------------------------------------------------
+; if 1 == standby_mode, then support super standby;
+; else, support normal standby.
+;---------------------------------------------------------------------------------------------------------
+[pm_para]
+standby_mode		= 1
+
+[card0_boot_para]
+card_ctrl       = 0
+card_high_speed = 1
+card_line       = 4
+sdc_d1          = port:PF00<2><1><2><default>
+sdc_d0          = port:PF01<2><1><2><default>
+sdc_clk         = port:PF02<2><1><2><default>
+sdc_cmd         = port:PF03<2><1><2><default>
+sdc_d3          = port:PF04<2><1><2><default>
+sdc_d2          = port:PF05<2><1><2><default>
+
+[card2_boot_para]
+card_ctrl       = 2
+card_high_speed = 1
+card_line       = 8
+sdc_cmd         = port:PC06<3><1><2><default>
+sdc_clk         = port:PC05<3><1><2><default>
+sdc_d0          = port:PC08<3><1><2><default>
+sdc_d1          = port:PC09<3><1><2><default>
+sdc_d2          = port:PC10<3><1><2><default>
+sdc_d3          = port:PC11<3><1><2><default>
+sdc_d4          = port:PC12<3><1><2><default>
+sdc_d5          = port:PC13<3><1><2><default>
+sdc_d6          = port:PC14<3><1><2><default>
+sdc_d7          = port:PC15<3><1><2><default>
+sdc_2xmode   	= 1
+sdc_ddrmode		= 1
+
+[twi_para]
+twi_port        = 0
+twi_scl         = port:PA11<2><default><default><default>
+twi_sda         = port:PA12<2><default><default><default>
+
+[uart_para]
+uart_debug_port = 0
+uart_debug_tx   = port:PA04<2><1><default><default>
+uart_debug_rx   = port:PA05<2><1><default><default>
+
+[force_uart_para]
+force_uart_port  = 0
+force_uart_tx    = port:PF02<3><1><default><default>
+force_uart_rx    = port:PF04<3><1><default><default>
+
+[jtag_para]
+jtag_enable     = 0
+jtag_ms         = port:PA00<3><default><default><default>
+jtag_ck         = port:PA01<3><default><default><default>
+jtag_do         = port:PA02<3><default><default><default>
+jtag_di         = port:PA03<3><default><default><default>
+
+[clock]
+pll_video        = 297
+pll_ve           = 402
+pll_periph0      = 600
+pll_gpu          = 576
+pll_periph1      = 600
+pll_de           = 864
+
+;*****************************************************************************
+;sdram configuration
+;
+;dram_para2 = 0x00001200  ;Representative enable dram Dual
+;
+;dram_para2 = 0x00001100  ;on behalf of a single channel is enabled dram
+;
+;*****************************************************************************
+[dram_para]
+dram_clk        = 672
+dram_type       = 3
+dram_zq         = 0x3b3bfb
+dram_odt_en     = 0x1
+dram_para1      = 0x10E40000
+dram_para2      = 0x0000
+dram_mr0        = 0x1840
+dram_mr1        = 0x40
+dram_mr2        = 0x18
+dram_mr3        = 0x2
+dram_tpr0       = 0x0048A192
+dram_tpr1       = 0x01C2418D
+dram_tpr2       = 0x00076051
+dram_tpr3       = 0
+dram_tpr4       = 0
+dram_tpr5       = 0
+dram_tpr6       = 100
+dram_tpr7       = 0
+dram_tpr8       = 0
+dram_tpr9       = 0
+dram_tpr10      = 0
+dram_tpr11      = 0x6aaa0000
+dram_tpr12      = 0x7979
+dram_tpr13      = 0x800800
+;----------------------------------------------------------------------------------
+;os life cycle para configuration
+;----------------------------------------------------------------------------------
+
+;---------------------------------------------------------------------------------------------------------
+; wakeup_src_para:
+;	sometimes, u would like to add more wakeup src in standby mode, these para will be
+;	help;
+;	u need to make sure the standby mode support the wakeup src. Also, some hw
+;	condition must be guaranteed.
+;	including:
+;	cpu_en: power on or off.
+;		1: mean power on
+;		0: mean power off
+;	cpu_freq: indicating lowest freq. unit is Mhz;
+;	dram selfresh_en: selfresh or not.
+;		1: enable enter selfresh
+;		0: disable enter selfresh
+;	dram_pll: if not enter selfresh, indicating lowest freq. unit is Mhz;
+;	wakeup_src: to make the scenario work, the wakeup src is needed.
+;---------------------------------------------------------------------------------------------------------
+[wakeup_src_para]
+cpu_en              = 0
+cpu_freq            = 48
+; (cpu:apb:ahb)
+pll_ratio           = 0x111
+dram_selfresh_en    = 1
+dram_freq           = 36
+wakeup_src0         =
+wakeup_src_wl       = port:PG10<4><default><default><0>
+wakeup_src_bt       = port:PL03<6><default><default><0>
+
+;----------------------------------------------------------------------------------
+;i2c configuration
+;----------------------------------------------------------------------------------
+[twi0]
+twi_used        = 1
+twi_scl         = port:PA11<2><default><default><default>
+twi_sda         = port:PA12<2><default><default><default>
+
+[twi1]
+twi_used        = 1
+twi_scl         = port:PA18<3><default><default><default>
+twi_sda         = port:PA19<3><default><default><default>
+
+[twi2]
+twi_used        = 0
+twi_scl         = port:PE12<3><default><default><default>
+twi_sda         = port:PE13<3><default><default><default>
+
+;----------------------------------------------------------------------------------
+;uart configuration
+;uart_type ---  2 (2 wire), 4 (4 wire), 8 (8 wire, full function)
+;----------------------------------------------------------------------------------
+[uart0]
+uart_used       = 1
+uart_port       = 0
+uart_type       = 2
+uart_tx         = port:PA04<2><1><default><default>
+uart_rx         = port:PA05<2><1><default><default>
+
+[uart1]
+uart_used       = 0
+uart_port       = 1
+uart_type       = 2
+uart_tx         = port:PG06<2><1><default><default>
+uart_rx         = port:PG07<2><1><default><default>
+uart_rts        = port:PG08<2><1><default><default>
+uart_cts        = port:PG09<2><1><default><default>
+
+[uart2]
+uart_used       = 1
+uart_port       = 2
+uart_type       = 4
+uart_tx         = port:PA00<2><1><default><default>
+uart_rx         = port:PA01<2><1><default><default>
+uart_rts        = port:PA02<2><1><default><default>
+uart_cts        = port:PA03<2><1><default><default>
+
+[uart3]
+uart_used       = 1
+uart_port       = 3
+uart_type       = 2
+uart_tx         = port:PA13<3><1><default><default>
+uart_rx         = port:PA14<3><1><default><default>
+uart_rts        = port:PA15<3><1><default><default>
+uart_cts        = port:PA16<3><1><default><default>
+
+;----------------------------------------------------------------------------------
+;SPI controller configuration
+;----------------------------------------------------------------------------------
+[spi0]
+spi_used       = 1
+spi_cs_bitmap  = 1
+spi_mosi       = port:PC00<3><default><default><default>
+spi_miso       = port:PC01<3><default><default><default>
+spi_sclk       = port:PC02<3><default><default><default>
+spi_cs0        = port:PC03<3><1><default><default>
+
+[spi1]
+spi_used       = 0
+spi_cs_bitmap  = 1
+spi_cs0        = port:PA13<2><1><default><default>
+spi_sclk       = port:PA14<2><default><default><default>
+spi_mosi       = port:PA15<2><default><default><default>
+spi_miso       = port:PA16<2><default><default><default>
+
+;----------------------------------------------------------------------------------
+;SPI device configuration
+;----------------------------------------------------------------------------------
+[spi_devices]
+spi_dev_num = 1
+
+[spi_board0]
+modalias      = "spidev"
+max_speed_hz  = 33000000
+bus_num       = 0
+chip_select   = 0
+mode          = 0
+full_duplex   = 1
+manual_cs     = 0
+
+;----------------------------------------------------------------------------------
+;userspace gpio interface
+; ** COMMENT THE PINS USED IN OTHER INTERFACES (I2C, SPI, 1-WIRE...)
+;----------------------------------------------------------------------------------
+[gpio_para]
+gpio_used = 1
+gpio_num = 19
+gpio_pin_1       = port:PA06<1><default><default><0>
+gpio_pin_2       = port:PA13<1><default><default><0>
+gpio_pin_3       = port:PA14<1><default><default><0>
+gpio_pin_4       = port:PA01<1><default><default><0>
+gpio_pin_5       = port:PD14<1><default><default><0>
+gpio_pin_6       = port:PA00<1><default><default><0>
+gpio_pin_7       = port:PA03<1><default><default><0>
+gpio_pin_8       = port:PC04<1><default><default><0>
+gpio_pin_9       = port:PC07<1><default><default><0>
+gpio_pin_10      = port:PA02<1><default><default><0>
+gpio_pin_11      = port:PA21<1><default><default><0>
+gpio_pin_12      = port:PA07<1><default><default><0>
+gpio_pin_13      = port:PA08<1><default><default><0>
+gpio_pin_14      = port:PG08<1><default><default><0>
+gpio_pin_15      = port:PA09<1><default><default><0>
+gpio_pin_16      = port:PA10<1><default><default><0>
+gpio_pin_17      = port:PG09<1><default><default><0>
+gpio_pin_18      = port:PG06<1><default><default><0>
+gpio_pin_19      = port:PG07<1><default><default><0>
+
+;[led_assign]
+;normal_led      = "gpio_pin_2"
+;standby_led     = "gpio_pin_1"
+
+[leds_para]
+leds_used = 1
+green_led = port:PL10<1><default><default><0>
+green_led_active_low = 0
+red_led = port:PA15<1><default><default><0>
+red_led_active_low = 1
+
+;----------------------------------------------------------------------------------
+;thermal configuration
+;ths_trip_count : temperature trigger number
+;ths_trip_0 : first temperature trigger
+;ths_trip_1 : second temperature trigger
+;ths_trip_2 : third temperature trigger, when upto this temperature, system shutdown
+;ths_trip_0_min : first temperature trigger's min freq
+;ths_trip_0_max : first temperature trigger's max freq
+;ths_trip_1_min : second temperature trigger's min freq
+;ths_trip_1_max : second temperature trigger's max freq
+;----------------------------------------------------------------------------------
+
+[ths_para]
+ths_used = 1
+ths_trip1_count = 6
+ths_trip1_0 = 70
+ths_trip1_1 = 80
+ths_trip1_2 = 85
+ths_trip1_3 = 90
+ths_trip1_4 = 95
+ths_trip1_5 = 100
+ths_trip1_6 = 0
+ths_trip1_7 = 0
+ths_trip1_0_min = 0
+ths_trip1_0_max = 1
+ths_trip1_1_min = 1
+ths_trip1_1_max = 2
+ths_trip1_2_min = 2
+ths_trip1_2_max = 3
+ths_trip1_3_min = 3
+ths_trip1_3_max = 4
+ths_trip1_4_min = 4
+ths_trip1_4_max = 5
+ths_trip1_5_min = 5
+ths_trip1_5_max = 5
+ths_trip1_6_min = 0
+ths_trip1_6_max = 0
+ths_trip2_count = 1
+ths_trip2_0 = 105
+
+;----------------------------------------------------------------------------------
+;cooler_table  cooler_count <=32
+;----------------------------------------------------------------------------------
+
+[cooler_table]
+cooler_count = 6
+cooler0 = "1296000 4 4294967295 0"
+cooler1 = "1200000 4 4294967295 0"
+cooler2 = "1008000 4 4294967295 0"
+cooler3 =  "816000 4 4294967295 0"
+cooler4 =  "648000 4 4294967295 0"
+cooler5 =  "480000 1 4294967295 0"
+
+[nand0_para]
+nand_support_2ch    = 0
+
+nand0_used          = 0
+nand0_we            = port:PC00<2><default><default><default>
+nand0_ale           = port:PC01<2><default><default><default>
+nand0_cle           = port:PC02<2><default><default><default>
+nand0_ce1           = port:PC03<2><default><default><default>
+nand0_ce0           = port:PC04<2><default><default><default>
+nand0_nre           = port:PC05<2><default><default><default>
+nand0_rb0           = port:PC06<2><default><default><default>
+nand0_rb1           = port:PC07<2><default><default><default>
+nand0_d0            = port:PC08<2><default><default><default>
+nand0_d1            = port:PC09<2><default><default><default>
+nand0_d2            = port:PC10<2><default><default><default>
+nand0_d3            = port:PC11<2><default><default><default>
+nand0_d4            = port:PC12<2><default><default><default>
+nand0_d5            = port:PC13<2><default><default><default>
+nand0_d6            = port:PC14<2><default><default><default>
+nand0_d7            = port:PC15<2><default><default><default>
+nand0_ndqs          = port:PC16<2><default><default><default>
+
+
+;-----------------------------------------------------------------
+;auto_hpd    -   1:need hotplud for hdmi/tv;  0:don't hotplud for lcd
+;output_type -   0:none; 1:lcd; 2:tv; 4:hdmi; 8:vga (as default config in homlet)
+;hdmi_channel-   the display channel for hdmi (as default config in homlet)
+;cvbs_channel-   the display channel for cvbs (as default config in homlet)
+;hdmi_mode   -   as default config for output of hdmi in homlet
+;cvbs_mode   -   as default config for output of tv in homlet. 11:PAL; 14:NTSC
+;check the definition(of hdmi/cvbs_mode) of disp_tv_mode in sunxi_display2.h
+;hdmi_mode_check - disable/enable the function of checking hdmi mode, 0 is disable, 1 is enable
+;-----------------------------------------------------------------
+[boot_disp]
+advert_disp     = 0
+auto_hpd        = 1
+output_type     = 4
+hdmi_channel    = 0
+hdmi_mode       = 4
+cvbs_channel    = 1
+cvbs_mode       = 11
+output_full     = 1
+hdmi_mode_check = 1
+
+;----------------------------------------------------------------------------------
+;disp init configuration
+;
+;disp_mode             (0:screen0<screen0,fb0>; 1:screen1<screen1,fb0>)
+;screenx_output_type  (0:none; 1:lcd; 3:hdmi;)
+;screenx_output_mode  (used for hdmi output, 0:480i 1:576i 2:480p 3:576p 4:720p50)
+;                     (5:720p60 6:1080i50 7:1080i60 8:1080p24 9:1080p50 10:1080p60)
+;fbx format           (0:ARGB 1:ABGR 2:RGBA 3:BGRA 5:RGB565 8:RGB888 12:ARGB4444 16:ARGB1555 18:RGBA5551)
+;fbx_width,fbx_height (framebuffer horizontal/vertical pixels, fix to output resolution while equal 0)
+;lcdx_backlight       (lcd init backlight,the range:[0,256],default:197
+;----------------------------------------------------------------------------------
+[disp_init]
+disp_init_enable         = 1
+disp_mode                = 0
+
+screen0_output_type      = 3
+screen0_output_mode      = 5
+
+screen1_output_type      = 3
+screen1_output_mode      = 5
+
+fb0_format               = 0
+fb0_width                = 0
+fb0_height               = 0
+
+fb1_format               = 0
+fb1_width                = 0
+fb1_height               = 0
+
+fb0_framebuffer_num      = 3
+sunxi_fb_mem_reserve     = 32
+    
+;----------------------------------------------------------------------------------
+;hdmi configuration
+;----------------------------------------------------------------------------------
+[hdmi_para]
+hdmi_used              = 1
+hdmi_power             = "vcc-hdmi-18"
+;-------------------------------------
+; set to 0 for hdmi->dvi compatibility
+;-------------------------------------
+;hdcp_enable            = 0
+;hdmi_cts_compatibility = 1
+
+[tv_para]
+tv_used				= 1
+tv_dac_used			= 1
+tv_dac_src0			= 0
+
+;----------------------------------------------------------------------------------
+;pwm config
+;----------------------------------------------------------------------------------
+[pwm0_para]
+pwm_used            = 0
+pwm_positive        = port:PA05<3><0><default><default>
+
+;------------------------------------------------------------------------------;
+; 10/100/100Mbps Ethernet MAC Controller Configure                             ;
+;------------------------------------------------------------------------------;
+;   Options:                                                                   ;
+;   gmac_used  ---  0: not used, 1: external phy, 2: internal phy              ;
+;   gmac_powerx --  A[:B] A: axp channel, B: voltage value                     ;
+;       If set gamc_phy to use internal PHY, do not config port                ;
+;------------------------------------------------------------------------------;
+;         MII        RMII         MII        RMII         MII        RMII      ;
+;   PD00  *                 PD06   *           *    PD12   *           *       ;
+;   PD01  *                 PD07   *                PD13   *           *       ;
+;   PD02  *            *    PD08   *                PD14   *                   ;
+;   PD03  *            *    PD09   *           *    PD15   *                   ;
+;   PD04  *                 PD10   *           *    PD16   *           *       ;
+;   PD05  *                 PD11   *           *    PD17   *           *       ;
+;------------------------------------------------------------------------------;
+[gmac0]
+gmac_used          = 1
+gmac_rxd3          = port:PD00<2><default><3><default>
+gmac_rxd2          = port:PD01<2><default><3><default>
+gmac_rxd1          = port:PD02<2><default><3><default>
+gmac_rxd0          = port:PD03<2><default><3><default>
+gmac_rxclk         = port:PD04<2><default><3><default>
+gmac_rxdv          = port:PD05<2><default><3><default>
+;gmac_rxerr         = port:PD06<2><default><3><default>
+gmac_txd3          = port:PD07<2><default><3><default>
+gmac_txd2          = port:PD08<2><default><3><default>
+gmac_txd1          = port:PD09<2><default><3><default>
+gmac_txd0          = port:PD10<2><default><3><default>
+;gmac_crs           = port:PD11<2><default><3><default>
+gmac_txclk         = port:PD12<2><default><3><default>
+gmac_txen          = port:PD13<2><default><3><default>
+;gmac_txerr         = port:PD14<2><default><3><default>
+gmac_col           = port:PD15<2><default><3><default>
+gmac_mdc           = port:PD16<2><default><3><default>
+gmac_mdio          = port:PD17<2><default><3><default>
+gmac_power1        =
+
+[gmac_phy_power]
+gmac_phy_power_en   = port:PD06<1><default><default><0>
+
+;--------------------------------------------------------------------------------
+;vip (video input port) configuration
+;vip_used: 0:disable 1:enable
+;vip_mode: 0:sample one interface to one buffer 1:sample two interface to one buffer
+;vip_dev_qty: The quantity of devices linked to capture bus
+;
+;vip_define_sensor_list: If you want use sensor detect function, please set vip_define_sensor_list = 1, and
+;                                    verify that file /system/etc/hawkview/sensor_list_cfg.ini is properly configured!
+;
+;vip_dev(x)_pos: sensor position, "rear" or "front", if vip_define_sensor_list = 1,
+;vip_dev(x)_pos must be configured!
+;
+;vip_dev(x)_isp_used 0:not use isp 1:use isp
+;vip_dev(x)_fmt: 0:yuv 1:bayer raw rgb
+;vip_dev(x)_stby_mode: 0:not shut down power at standby 1:shut down power at standby
+;vip_dev(x)_vflip: flip in vertical direction 0:disable 1:enable
+;vip_dev(x)_hflip: flip in horizontal direction 0:disable 1:enable
+;vip_dev(x)_iovdd: camera module io power handle string, pmu power supply
+;vip_dev(x)_iovdd_vol: camera module io power voltage, pmu power supply
+;vip_dev(x)_avdd:	camera module analog power handle string, pmu power supply
+;vip_dev(x)_avdd_vol:	camera module analog power voltage, pmu power supply
+;vip_dev(x)_dvdd:	camera module core power handle string, pmu power supply
+;vip_dev(x)_dvdd_vol:	camera module core power voltage, pmu power supply
+;vip_dev(x)_afvdd:	camera module vcm power handle string, pmu power supply
+;vip_dev(x)_afvdd_vol:	camera module vcm power voltage, pmu power supply
+;x indicates the index of the devices which are linked to the same capture bus
+;fill voltage in uV, e.g. iovdd = 2.8V, vip_devx_iovdd_vol = 2800000
+;fill handle string as below:
+;axp22_eldo3
+;axp22_dldo4
+;axp22_eldo2
+;fill handle string "" when not using any pmu power supply
+;--------------------------------------------------------------------------------
+
+[csi0]
+
+vip_used                 = 1
+vip_mode                 = 0
+vip_dev_qty              = 1
+vip_define_sensor_list   = 0
+
+vip_csi_pck              = port:PE00<2><default><default><default>
+vip_csi_mck              = port:PE01<2><default><default><default>
+vip_csi_hsync            = port:PE02<2><default><default><default>
+vip_csi_vsync            = port:PE03<2><default><default><default>
+vip_csi_d0               = port:PE04<2><default><default><default>
+vip_csi_d1               = port:PE05<2><default><default><default>
+vip_csi_d2               = port:PE06<2><default><default><default>
+vip_csi_d3               = port:PE07<2><default><default><default>
+vip_csi_d4               = port:PE08<2><default><default><default>
+vip_csi_d5               = port:PE09<2><default><default><default>
+vip_csi_d6               = port:PE10<2><default><default><default>
+vip_csi_d7               = port:PE11<2><default><default><default>
+vip_csi_sck              = port:PE12<2><default><default><default>
+vip_csi_sda              = port:PE13<2><default><default><default>
+
+vip_dev0_mname           = "gc2035"
+vip_dev0_pos             = "front"
+vip_dev0_lane            = 1
+vip_dev0_twi_id          = 2
+vip_dev0_twi_addr        = 0x78
+vip_dev0_isp_used        = 0
+vip_dev0_fmt             = 0
+vip_dev0_stby_mode       = 0
+vip_dev0_vflip           = 1
+vip_dev0_hflip           = 1
+vip_dev0_iovdd           = ""
+vip_dev0_iovdd_vol       = 2800000
+vip_dev0_avdd            = ""
+vip_dev0_avdd_vol        = 2800000
+vip_dev0_dvdd            = ""
+vip_dev0_dvdd_vol        = 1800000
+vip_dev0_afvdd           = ""
+vip_dev0_afvdd_vol       = 2800000
+vip_dev0_power_en        = port:PA17<1><default><default><1>
+vip_dev0_reset           = port:PE14<1><default><default><1>
+vip_dev0_pwdn            = port:PE15<1><default><default><0>
+vip_dev0_flash_en        =
+vip_dev0_flash_mode      =
+vip_dev0_af_pwdn         =
+
+vip_dev0_act_used        = 0
+vip_dev0_act_name        = "ad5820_act"
+vip_dev0_act_slave       = 0x18
+
+
+vip_dev1_mname           = ""
+vip_dev1_pos             = "rear"
+vip_dev1_lane            = 1
+vip_dev1_twi_id          = 0
+vip_dev1_twi_addr        =
+vip_dev1_isp_used        = 0
+vip_dev1_fmt             = 1
+vip_dev1_stby_mode       = 0
+vip_dev1_vflip           = 0
+vip_dev1_hflip           = 0
+vip_dev1_iovdd           = ""
+vip_dev1_iovdd_vol       = 2800000
+vip_dev1_avdd            = ""
+vip_dev1_avdd_vol        = 2800000
+vip_dev1_dvdd            = ""
+vip_dev1_dvdd_vol        = 1500000
+vip_dev1_afvdd           = ""
+vip_dev1_afvdd_vol       = 2800000
+vip_dev1_power_en        =
+vip_dev1_reset           =
+vip_dev1_pwdn            =
+vip_dev1_flash_en        =
+vip_dev1_flash_mode      =
+vip_dev1_af_pwdn         =
+
+
+;--------------------------------------------------------------------------------
+;tv configuration
+;
+;--------------------------------------------------------------------------------
+[tvout_para]
+tvout_used          =
+tvout_channel_num   =
+tv_en               =
+
+[tvin_para]
+tvin_used           =
+tvin_channel_num    =
+
+;----------------------------------------------------------------------------------
+;DE-Interlace configuration
+;----------------------------------------------------------------------------------
+[di_para]
+di_used           = 1
+
+;--------------------------------------------------------------------------------
+;   SDMMC PINS MAPPING                                                          |
+; ------------------------------------------------------------------------------|
+;   Config Guide                                                                |
+;   sdc_used: 1-enable card, 0-disable card                                     |
+;   sdc_detmode: card detect mode                                               |
+;                1-detect card by gpio polling                                  |
+;                2-detect card by gpio irq(must use IO with irq function)       |
+;                3-no detect, always in for boot card                           |
+;                4-manually insert and remove by /proc/driver/sunxi-mmc.x/insert|
+;   sdc_buswidth: card bus width, 1-1bit, 4-4bit, 8-8bit                        |
+;   sdc_use_wp: 1-with write protect IO, 0-no write protect IO                  |
+;   sdc_isio: for sdio card                                                     |
+;   sdc_regulator: power control.if card supports UHS-I/DDR and HS200 timing for|
+;                  SD3.0 or eMMC4.5, regulator must be configured. the value is |
+;                  the ldo name of AXP221, eg: sdc_regulator = "axp22_eldo2"    |
+;   other: GPIO Mapping configuration                                           |
+; ------------------------------------------------------------------------------|
+;   Note:                                                                       |
+;   1 if detmode=2, sdc_det's config=6                                          |
+;     else if detmode=1, sdc_det's config=0                                     |
+;     else sdc_det IO is not necessary                                          |
+;   2 if the customer wants to support UHS-I and HS200 features, he must provide|
+;     an independent power supply for the card. This is only used in platforms  |
+;     that supports SD3.0 cards and eMMC4.4+ flashes                            |
+;--------------------------------------------------------------------------------
+[mmc0_para]
+sdc_used          = 1
+sdc_detmode       = 3
+sdc_buswidth      = 4
+sdc_clk           = port:PF02<2><1><2><default>
+sdc_cmd           = port:PF03<2><1><2><default>
+sdc_d0            = port:PF01<2><1><2><default>
+sdc_d1            = port:PF00<2><1><2><default>
+sdc_d2            = port:PF05<2><1><2><default>
+sdc_d3            = port:PF04<2><1><2><default>
+sdc_det           = port:PF06<0><1><2><default>
+sdc_use_wp        = 0
+sdc_wp            =
+sdc_isio          = 0
+sdc_regulator     = "none"
+sdc_power_supply  = "none"
+
+[mmc1_para]
+sdc_used          = 1
+sdc_detmode       = 4
+sdc_buswidth      = 4
+sdc_clk           = port:PG00<2><1><3><default>
+sdc_cmd           = port:PG01<2><1><3><default>
+sdc_d0            = port:PG02<2><1><3><default>
+sdc_d1            = port:PG03<2><1><3><default>
+sdc_d2            = port:PG04<2><1><3><default>
+sdc_d3            = port:PG05<2><1><3><default>
+sdc_det           =
+sdc_use_wp        = 0
+sdc_wp            =
+sdc_isio          = 1
+sdc_regulator     = "none"
+sdc_power_supply  = "none"
+sdc_2xmode        = 1
+sdc_ddrmode       = 1
+
+[mmc2_para]
+sdc_used          = 1
+sdc_detmode       = 1
+sdc_buswidth      = 8
+sdc_clk           = port:PC05<3><1><2><default>
+sdc_cmd           = port:PC06<3><1><2><default>
+sdc_d0            = port:PC08<3><1><2><default>
+sdc_d1            = port:PC09<3><1><2><default>
+sdc_d2            = port:PC10<3><1><2><default>
+sdc_d3            = port:PC11<3><1><2><default>
+sdc_d4            = port:PC12<3><1><2><default>
+sdc_d5            = port:PC13<3><1><2><default>
+sdc_d6            = port:PC14<3><1><2><default>
+sdc_d7            = port:PC15<3><1><2><default>
+emmc_rst          = port:PC16<3><1><2><default>
+sdc_det           =
+sdc_use_wp        = 0
+sdc_wp            =
+sdc_isio          = 0
+sdc_regulator     = "none"
+sdc_power_supply  = "none"
+sdc_2xmode        = 1
+sdc_ddrmode       = 1
+
+; ------------------------------------------------------------------------------|
+; sim card configuration
+;--------------------------------------------------------------------------------
+[smc_para]
+smc_used            = 0
+smc_rst             = port:PA09<2><default><default><default>
+smc_vppen           = port:PA20<3><default><default><default>
+smc_vppp            = port:PA21<3><default><default><default>
+smc_det             = port:PA10<2><default><default><default>
+smc_vccen           = port:PA06<2><default><default><default>
+smc_sck             = port:PA07<2><default><default><default>
+smc_sda             = port:PA08<2><default><default><default>
+
+
+;--------------------------------
+; [usbc0]: Controller 0 configuration.
+; usb used:          USB enable flag. Set, indicating that the system USB module is available, is set to 0, it means that the system USB is disabled.
+; usb_port_type:     USB port usage. 0: device only; 1: host only; 2: OTG
+; usb_detect_type:   USB port of checking. 0: not detected; 1: vbus / id checks; 2: id / dpdm check
+; usb_id_gpio:       USB ID pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_det_vbus_gpio: USB DET_VBUS pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_drv_vbus_gpio: USB DRY_VBUS pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_det_vbus_gpio: "axp_ctrl", represents axp offer
+; usb_restrict_gpio: usb limiting control pin
+; usb_restric_flag:  usb limiting standard set
+;--------------------------------
+;--------------------------------
+;---       USB0控制标志
+;--------------------------------
+[usbc0]
+usb_used            = 1
+;usb_port_type       = 2
+usb_port_type       = 1
+;usb_detect_type     = 1
+usb_detect_type     = 0
+usb_id_gpio         =
+usb_det_vbus_gpio   =
+usb_drv_vbus_gpio   = port:PL02<1><0><default><0>
+usb_host_init_state = 1
+usb_restrict_gpio   =
+usb_restric_flag    = 0
+usb_restric_voltage = 3550000
+usb_restric_capacity= 5
+usb_regulator_io    = "nocare"
+usb_regulator_vol   = 0
+usb_not_suspend     = 0
+
+;--------------------------------
+;---       USB1控制标志
+;--------------------------------
+[usbc1]
+usb_used            = 1
+usb_drv_vbus_gpio   = port:PG13<1><0><default><0>
+usb_restrict_gpio   =
+usb_host_init_state = 1
+usb_restric_flag    = 0
+usb_regulator_io    = "nocare"
+usb_regulator_vol   = 0
+usb_not_suspend     = 0
+
+;--------------------------------
+;---       USB2控制标志
+;--------------------------------
+[usbc2]
+usb_used            = 0
+usb_drv_vbus_gpio   = 
+usb_restrict_gpio   =
+usb_host_init_state = 1
+usb_restric_flag    = 0
+usb_regulator_io    = "nocare"
+usb_regulator_vol   = 0
+usb_not_suspend     = 0
+
+;--------------------------------
+;---       USB3控制标志
+;--------------------------------
+[usbc3]
+usb_used            = 1
+;usb_drv_vbus_gpio   = port:PG11<1><default><default><1>
+usb_drv_vbus_gpio   = 
+usb_restrict_gpio   =
+usb_host_init_state = 1
+usb_restric_flag    = 0
+usb_regulator_io    = "nocare"
+usb_regulator_vol   = 0
+usb_not_suspend     = 0
+
+;--------------------------------
+;---       USB Device
+;--------------------------------
+[usb_feature]
+vendor_id           = 0x18D1
+mass_storage_id     = 0x0001
+adb_id              = 0x0002
+
+manufacturer_name   = "USB Developer"
+product_name        = "Android"
+serial_number       = "20080411"
+
+[msc_feature]
+vendor_name         = "USB 2.0"
+product_name        = "USB Flash Driver"
+release             = 100
+luns                = 3
+
+[serial_feature]
+serial_unique       = 0
+
+
+;--------------------------------------------------------------------------------
+;wifi/bt/fm/gps/nfc modules configuration
+;module_num:
+;             0- none
+;             1- rtl8188eu(wifi)
+;             2- rtl8723bs(wifi+bt)
+;             3- ap6181(wifi)
+;             4- ap6210(wifi+bt)
+;             5- ap6330(wifi+bt)
+;             6- ap6335(wifi)
+;             7- rtl8189etv(wifi)
+;module_power0: axp used by module, "axp22_dldo1" - use dldo1, not use keep it empty
+;module_power0_vol: power0 voltage, mv;
+;chip_en:       enable chip io
+;lpo_use_apclk: ""- not use, "losc_out"- a23/33/H3, "ac10032k1"、"ac10032k2"、"ac10032k3"- a80
+;--------------------------------------------------------------------------------
+[module_para]
+module_num          = 7
+module_power0       = "vcc-wifi-33"
+module_power0_vol   = 0
+module_power1       =
+module_power1_vol   =
+module_power2       =
+module_power2_vol   =
+module_power3       =
+module_power3_vol   =
+chip_en             =
+lpo_use_apclk       =
+
+;--------------------------------------------------------------------------------
+;wifi configuration
+;wifi_sdc_id:    0- SDC0, 1- SDC1, 2- SDC2, 3- SDC3
+;wifi_usbc_id:   0- USB0, 1- USB1, 2- USB2
+;wifi_usbc_type: 1- EHCI(speed 2.0), 2- OHCI(speed 1.0)
+;wl_reg_on:      wifi function enable pin
+;wl_host_wake:   wlan device wake-up host pin
+;wl_host_wake_invert: whether wl_host_wake use inverter between ap and module
+;                     0: not used, 1: used
+;--------------------------------------------------------------------------------
+[wifi_para]
+wifi_used             = 1
+wifi_sdc_id           = 1
+wifi_usbc_id          = 2
+wifi_usbc_type        = 1
+wl_reg_on             = port:PL07<1><default><default><0>
+wl_host_wake          = port:PG10<0><default><default><0> 
+wl_host_wake_invert   = 0
+
+;--------------------------------------------------------------------------------
+;bluetooth configuration
+;bt_used:       0- no used, 1- used
+;bt_uard_id:		0- uart0, 1- uart1, 2- uart2
+;bt_rst_n:      bt function enable io
+;bt_wake:       host wake-up bluetooth device
+;bt_host_wake:  bt device wake-up host
+;bt_host_wake_invert: whether bt_host_wake use inverter between ap and module
+;                     0: not used, 1: used
+;--------------------------------------------------------------------------------
+[bt_para]
+bt_used               = 0
+bt_uart_id            = 1
+bt_rst_n              =
+bt_wake               =
+bt_host_wake          =
+bt_host_wake_invert   = 0
+
+;--------------------------------------------------------------------------------
+;daudio_master:1: SND_SOC_DAIFMT_CBM_CFM(codec clk & FRM master)        use
+;			2: SND_SOC_DAIFMT_CBS_CFM(codec clk slave & FRM master)  not use
+;			3: SND_SOC_DAIFMT_CBM_CFS(codec clk master & frame slave) not use
+;			4: SND_SOC_DAIFMT_CBS_CFS(codec clk & FRM slave)         use
+;daudio_select:0 is pcm.1 is i2s
+;audio_format: 1:SND_SOC_DAIFMT_I2S(standard i2s format).            use
+;			   2:SND_SOC_DAIFMT_RIGHT_J(right justfied format).
+;			   3:SND_SOC_DAIFMT_LEFT_J(left justfied format)
+;			   4:SND_SOC_DAIFMT_DSP_A(pcm. MSB is available on 2nd BCLK rising edge after LRC rising edge). use
+;			   5:SND_SOC_DAIFMT_DSP_B(pcm. MSB is available on 1nd BCLK rising edge after LRC rising edge)
+;signal_inversion:1:SND_SOC_DAIFMT_NB_NF(normal bit clock + frame)  use
+;				  2:SND_SOC_DAIFMT_NB_IF(normal BCLK + inv FRM)
+;				  3:SND_SOC_DAIFMT_IB_NF(invert BCLK + nor FRM)  use
+;				  4:SND_SOC_DAIFMT_IB_IF(invert BCLK + FRM)
+;over_sample_rate: support 128fs/192fs/256fs/384fs/512fs/768fs
+;sample_resolution	:16bits/20bits/24bits
+;word_select_size 	:16bits/20bits/24bits/32bits
+;pcm_sync_period 	:16/32/64/128/256
+;msb_lsb_first 		:0: msb first; 1: lsb first
+;sign_extend 		:0: zero pending; 1: sign extend
+;slot_index 		:slot index: 0: the 1st slot - 3: the 4th slot
+;slot_width 		:8 bit width / 16 bit width
+;frame_width 		:0: long frame = 2 clock width;  1: short frame
+;tx_data_mode 		:0: 16bit linear PCM; 1: 8bit linear PCM; 2: 8bit u-law; 3: 8bit a-law
+;rx_data_mode 		:0: 16bit linear PCM; 1: 8bit linear PCM; 2: 8bit u-law; 3: 8bit a-law
+;--------------------------------------------------------------------------------
+[pcm0]
+daudio_used         = 0
+daudio_master		= 4
+daudio_select  		= 1
+audio_format		= 1
+signal_inversion	= 1
+mclk_fs				= 128
+sample_resolution   = 16
+slot_width_select 	= 32
+;pcm_sync_period 	= 256
+pcm_lrck_period		= 32
+pcm_lrckr_period 	= 1
+msb_lsb_first 	    = 0
+sign_extend 		= 0
+slot_index 		    = 0
+slot_width 		    = 32
+frame_width 		= 0
+tx_data_mode 		= 0
+rx_data_mode 		= 0
+i2s_mclk            = port:PA18<2><1><default><default>
+i2s_bclk            = port:PA19<2><1><default><default>
+i2s_dout0           = port:PA20<2><1><default><default>
+i2s_din             = port:PA21<2><1><default><default>
+
+
+[pcm1]
+daudio_used         = 0
+daudio_master		= 4
+daudio_select  		= 1
+audio_format		= 1
+signal_inversion	= 1
+mclk_fs				= 128
+sample_resolution   = 16
+slot_width_select 	= 32
+;pcm_sync_period 	= 256
+pcm_lrck_period		= 32
+pcm_lrckr_period 	= 1
+msb_lsb_first 	    = 0
+sign_extend 		= 0
+slot_index 		    = 0
+slot_width 		    = 32
+frame_width 		= 0
+tx_data_mode 		= 0
+rx_data_mode 		= 0
+i2s_mclk            = port:PG10<2><1><default><default>
+i2s_bclk            = port:PG11<2><1><default><default>
+i2s_dout0           = port:PG12<2><1><default><default>
+i2s_din             = port:PG13<2><1><default><default>
+
+
+[audio0]
+audio_used          	= 1
+lineout_vol				= 0x1f
+cap_vol					= 0x5
+audio_hp_ldo       		= "none"
+adcagc_used       		= 0
+adcdrc_used       		= 0
+dacdrc_used       		= 0
+adchpf_used       		= 0
+dachpf_used       		= 0
+audio_pa_ctrl          	= port:PA16<1><default><default><0>
+
+[spdif0]
+spdif_used          = 0
+spdif_dout          = port:PA17<2><1><default><default>
+
+[audiohub]
+hub_used    = 0
+codec_used 	= 1
+spdif_used 	= 1
+hdmi_used 	= 1
+
+;----------------------------------------------------------------------------------
+;ir rx --- infra remote configuration
+;----------------------------------------------------------------------------------
+[s_cir0]
+ir_used             = 1
+ir_rx               = port:PL11<2><1><default><default>
+ir_power_key_code0  = 0x57
+ir_addr_code0       = 0x9f00
+ir_power_key_code1  = 0x1a
+ir_addr_code1       = 0xfb04
+ir_power_key_code2  = 0x14
+ir_addr_code2       = 0x7F80
+ir_power_key_code3  = 0x15
+ir_addr_code3       = 0x7F80
+ir_power_key_code4  = 0x0b
+ir_addr_code4       = 0xF708
+ir_power_key_code5  = 0x03
+ir_addr_code5       = 0x00EF
+ir_power_key_code6  = 0x9f
+ir_addr_code6       = 0x4CB3
+ir_power_key_code7  = 0x0a
+ir_addr_code7       = 0x7748
+ir_power_key_code8  = 0x45
+ir_addr_code8       = 0xbd02
+ir_power_key_code9  = 0x4d
+ir_addr_code9       = 0xde21
+ir_power_key_code10  = 0x18
+ir_addr_code10       = 0xfe01
+ir_power_key_code11  = 0x57
+ir_addr_code11       = 0xff00
+ir_power_key_code12  = 0x4d
+ir_addr_code12       = 0xff40
+
+
+;----------------------------------------------------------------------------------
+;ir tx--- infra remote configuration
+;----------------------------------------------------------------------------------
+[cir]
+ir_used             = 1
+ir_tx               = port:PH07<2><default><default><default>
+
+
+;----------------------------------------------------------------------------------
+; dvfs voltage-frequency table configuration
+;
+; pmuic_type:0:none, 1:gpio, 2:i2c
+; pmu_gpio0: gpio config.
+; pmu_levelx: 0~9999: voltage(mV), 10000~90000:gpio0 state. voltage form high to low.
+;
+; extremity_freq(Hz): cpu extremity frequency when run benckmark or demo apk
+;                     1536MHz@1500mV with radiator, 1296MHz@1340mV without radiator
+; max_freq: cpu maximum frequency, based on Hz, can not be more than 1200MHz
+; min_freq: cpu minimum frequency, based on Hz, can not be less than 60MHz
+;
+; LV_count: count of LV_freq/LV_volt, must be < 16
+;
+; LV1: core vdd is 1.50v if cpu frequency is (1296Mhz,  1536Mhz]
+; LV2: core vdd is 1.34v if cpu frequency is (1200Mhz,  1296Mhz]
+; LV3: core vdd is 1.32v if cpu frequency is (1008Mhz,  1200Mhz]
+; LV4: core vdd is 1.20v if cpu frequency is (816Mhz,   1008Mhz]
+; LV5: core vdd is 1.10v if cpu frequency is (648Mhz,    816Mhz]
+; LV6: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+; LV7: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+; LV8: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+;
+;----------------------------------------------------------------------------------
+[dvfs_table]
+pmuic_type = 2
+pmu_gpio0         = port:PL06<1><1><2><1>
+pmu_level0        = 11300
+pmu_level1        = 01100
+extremity_freq = 1296000000
+max_freq = 1200000000
+min_freq = 480000000
+LV_count = 7
+LV1_freq = 1296000000
+LV1_volt = 1320
+LV2_freq = 1200000000
+LV2_volt = 1240
+LV3_freq = 1104000000
+LV3_volt = 1180
+LV4_freq = 1008000000
+LV4_volt = 1140
+LV5_freq = 960000000
+LV5_volt = 1080
+LV6_freq = 816000000
+LV6_volt = 1020
+LV7_freq = 480000000
+LV7_volt = 980
+
+[gpu_dvfs_table]
+
+G_LV_count = 3
+
+G_LV0_freq = 312000000
+G_LV0_volt = 1200000
+
+G_LV1_freq = 384000000
+G_LV1_volt = 1200000
+
+G_LV2_freq = 456000000
+G_LV2_volt = 1200000
+
+
+;----------------------------------------------------------------------------------
+;virtual device
+;virtual device for pinctrl testing
+;device have pin PA1 PA2
+;----------------------------------------------------------------------------------
+[Vdevice]
+Vdevice_used        = 0
+Vdevice_0           = port:PH10<5><1><2><default>
+Vdevice_1           = port:PH11<5><1><2><default>
+
+;----------------------------------------------------------------------------------
+;s_uart0 config parameters
+;s_uart_used  --s_uart0 whether used for arisc debugging
+;----------------------------------------------------------------------------------
+[s_uart0]
+s_uart_used       = 0
+s_uart_tx         = port:PL02<2><default><default><default>
+s_uart_rx         = port:PL03<2><default><default><default>
+
+;----------------------------------------------------------------------------------
+;s_rsb0 config parameters
+;s_rsb_used  --s_rsb0 whether used for arisc
+;----------------------------------------------------------------------------------
+[s_rsb0]
+s_rsb_used        = 1
+s_rsb_sck         = port:PL00<2><1><2><default>
+s_rsb_sda         = port:PL01<2><1><2><default>
+
+;----------------------------------------------------------------------------------
+;s_jtag0 config parameters
+;s_jtag0_used  --s_jtag0 whether used for arisc
+;
+;----------------------------------------------------------------------------------
+[s_jtag0]
+s_jtag_used        = 0
+s_jtag_tms         = port:PL04<2><1><2><default>
+s_jtag_tck         = port:PL05<2><1><2><default>
+s_jtag_tdo         = port:PL06<2><1><2><default>
+s_jtag_tdi         = port:PL07<2><1><2><default>
+
+;----------------------------------------------------------------------------------
+;s_powchk cpus power check
+;s_powchk_used  --power check whether used for arisc in super standby
+;  bit31:enable power updat, bit1:wakeup when power state exception
+;  bit0:wakeup when power consumption exception
+;s_power_reg the expected regs stand for power on/off state
+;s_system_power the limit maxmum power consumption when super standby (unit: mw)
+;
+;----------------------------------------------------------------------------------
+[s_powchk]
+s_powchk_used      = 0x80000000
+s_power_reg        = 0x00000000
+s_system_power     = 50
+
+;----------------------------------------------------------------------------------
+;scr configuration
+;----------------------------------------------------------------------------------
+[sim0]
+scr_used            = 0
+scr_vccen           = port:PA06<2><default><default><default>
+scr_slk             = port:PA07<2><default><default><default>
+scr_sda             = port:PA08<2><default><default><default>
+scr_rst             = port:PA09<2><default><default><default>
+scr_det             = port:PA10<2><default><default><default>
+
+
+;--------------------------------------------------------------------------------
+;tsc configuration
+;--------------------------------------------------------------------------------
+[ts0]
+tsc_used			= 0
+tsc_clk				= port:PE00<3><default><default><default>
+tsc_err				= port:PE01<3><default><default><default>
+tsc_sync			= port:PE02<3><default><default><default>
+tsc_dvld			= port:PE03<3><default><default><default>
+tsc_d0				= port:PE04<3><default><default><default>
+tsc_d1				= port:PE05<3><default><default><default>
+tsc_d2				= port:PE06<3><default><default><default>
+tsc_d3				= port:PE07<3><default><default><default>
+tsc_d4				= port:PE08<3><default><default><default>
+tsc_d5				= port:PE09<3><default><default><default>
+tsc_d6				= port:PE10<3><default><default><default>
+tsc_d7				= port:PE11<3><default><default><default>
+
+;--------------------------------------------------------------------------------
+;gpio key
+;--------------------------------------------------------------------------------
+[gpio_power_key]
+key_used				= 1
+key_io					= port:PL03<6><default><default><0>
+
+;----------------------------------------------------------------------------------
+; key para
+;
+; key_used		--0:not used, 1:used
+; key_cnt		--how many key button attach to keyadc.
+; key*_vol		--the threshold of input voltage of key.
+;
+; For example: if key2_vol < $(keyadc value) < key3_vol, then key3 be reported.
+;----------------------------------------------------------------------------------
+[key_para]
+key_used                  = 0
+key_cnt                   = 5
+key1_vol				  = 222
+key2_vol				  = 444
+key3_vol				  =	666
+key4_vol				  =	857
+key5_vol				  = 2000
+
+
+;----------------------------------------------------------------------------------
+;display seven segment para
+;----------------------------------------------------------------------------------
+[d7s_para]
+d7s_used				= 0
+din_gpio				= port:PD00<1><default><default><1>
+clk_gpio				= port:PD01<1><default><default><1>
+stb_gpio				= port:PD02<1><default><default><1>
+
+
+;----------------------------------------------------------------------------------
+;mali parameters
+;----------------------------------------------------------------------------------
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
+
+
+;----------------------------------------------------------------------------------
+;1wire parameters (default - PA20)
+;----------------------------------------------------------------------------------
+[w1_para]
+w1_used = 1
+gpio = 20

--- a/configuration.sh
+++ b/configuration.sh
@@ -236,6 +236,17 @@ case $BOARD in
 		GOVERNOR="interactive"
 	;;
 
+	bananapim2plus)#disabled
+		#description H3 quad core 1Gb SoC Wifi
+		LINUXFAMILY="sun8i"
+		BOOTCONFIG="bananapim2_plus_defconfig"
+		MODULES="ap6210 #gpio_sunxi #w1-sunxi #w1-gpio #w1-therm"
+		MODULES_NEXT="brcmfmac"
+		CPUMIN="0"
+		CPUMAX="0"
+		GOVERNOR="interactive"
+	;;
+
 	cubox-i)#enabled
 		#description Freescale iMx dual/quad core Wifi
 		#build 6

--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -24,7 +24,7 @@ RTC=$(awk '/rtc0/ {print $(NF)}' <"${TMPFILE}")
 HB_PCI=$(grep '16c3:abcd' "${TMPFILE}")
 HARDWARE=$(awk '/Hardware/ {print $3}' </proc/cpuinfo)
 GMAC=$(grep "sun6i_gmac" "${TMPFILE}")$(grep "gmac0-" "${TMPFILE}")
-ORANGEPIPHY="$(awk -F"PHY ID " '/PHY ID / {print $2}' <"${TMPFILE}")"
+SUN8IPHY="$(awk -F"PHY ID " '/PHY ID / {print $2}' <"${TMPFILE}")"
 LEDS=$(grep "green:ph02:led1" "${TMPFILE}")
 TERMINUS=$(lsusb | grep "1a40:0101")
 SWITCH=$(grep "BCM53125" "${TMPFILE}")
@@ -128,7 +128,7 @@ if [ "$ARCH" = "armv7l" ]; then
 			if [ $MEMTOTAL -gt 1500 ]; then
 				ID="Orange Pi+ 2"
 			fi
-			case ${ORANGEPIPHY} in
+			case ${SUN8IPHY} in
 			00441400*)
 				if [ "$WIFI8189ES" != "" ]; then
 					ID="Orange Pi 2"
@@ -141,10 +141,26 @@ if [ "$ARCH" = "armv7l" ]; then
 			ID="Orange Pi Lite"
 			echo 8 >/proc/irq/$(awk -F":" "/${WiFi}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 		elif [ $MEMTOTAL -gt 600 ]; then
-			ID="Orange Pi PC"
-			echo 8 >/proc/irq/$(awk -F":" "/${USB3}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			case ${SUN8IPHY} in
+			00441400*)
+				ID="Orange Pi PC"
+				echo 8 >/proc/irq/$(awk -F":" "/${USB3}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+				;;
+			*)
+				ID="Banana Pi M2+"
+				echo 8 >/proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+				;;
+			esac
 		else
 			ID="Orange Pi One"
+		fi
+		# prepare board/settings mismatch detection. If we cleanup board/config names then this
+		# might work for all boards later and can be moved from sun8i section further down to support
+		# all $HARDWARE variants
+		ScriptBinName="$(echo "${ID}" | tr '[:upper:]' '[:lower:]' | sed -e 's/+/plus/' -e 's/\ //g' -e 's/2mini$/2/g' -e 's/plus2$/plus/g').bin"
+		ScriptBinUsed="$(readlink -f "/boot/script.bin")"
+		if [ "X${ScriptBinName}" != "X${ScriptBinUsed##*/}" ]; then
+			:
 		fi
     fi
 fi


### PR DESCRIPTION
Tested with OPi PC -- still works. So all we need to fully support BPi M2+ is knowledge about the voltage regulator used and pin assignment of LEDs.