### PR TITLE
Enable board/settings mismatch detection for sun8i (trial balloon)

### DIFF
--- a/config/orangepilite.fex
+++ b/config/orangepilite.fex
@@ -541,7 +541,7 @@ usb_regulator_vol = 0
 usb_not_suspend = 0
 
 [usbc3]
-usb_used = 0
+usb_used = 1
 usb_drv_vbus_gpio =
 usb_restrict_gpio =
 usb_host_init_state = 1

--- a/config/orangepione.fex
+++ b/config/orangepione.fex
@@ -531,7 +531,7 @@ usb_regulator_vol = 0
 usb_not_suspend = 0
 
 [usbc2]
-usb_used = 0
+usb_used = 1
 usb_drv_vbus_gpio =
 usb_restrict_gpio =
 usb_host_init_state = 1
@@ -541,7 +541,7 @@ usb_regulator_vol = 0
 usb_not_suspend = 0
 
 [usbc3]
-usb_used = 0
+usb_used = 1
 usb_drv_vbus_gpio =
 usb_restrict_gpio =
 usb_host_init_state = 1

--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -13,6 +13,15 @@ if [ "X$1" != "Xstart" ]; then
 	exit 1
 fi
 
+create_motd_warning() {
+cat > /etc/update-motd.d/90-warning <<EOT
+#!/bin/bash
+echo -e "\e[0;91mAttention:\x1B[0m $1\n"
+rm "\$0"
+EOT
+chmod +x /etc/update-motd.d/90-warning
+} # create_motd_warning
+
 TMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 trap "rm \"${TMPFILE}\" ; exit 0" 0 1 2 3 15
 dmesg >"${TMPFILE}"
@@ -156,11 +165,12 @@ if [ "$ARCH" = "armv7l" ]; then
 		fi
 		# prepare board/settings mismatch detection. If we cleanup board/config names then this
 		# might work for all boards later and can be moved from sun8i section further down to support
-		# all $HARDWARE variants
+		# all $HARDWARE variants. Only check board after 1st login already happened to be not in
+		# conflict with our board auto detection mechanisms
 		ScriptBinName="$(echo "${ID}" | tr '[:upper:]' '[:lower:]' | sed -e 's/+/plus/' -e 's/\ //g' -e 's/2mini$/2/g' -e 's/plus2$/plus/g').bin"
 		ScriptBinUsed="$(readlink -f "/boot/script.bin")"
-		if [ "X${ScriptBinName}" != "X${ScriptBinUsed##*/}" ]; then
-			:
+		if [ "X${ScriptBinName}" != "X${ScriptBinUsed##*/}" -a ! -f "/root/.not_logged_in_yet" ]; then
+			create_motd_warning "It seems the image is running on ${ID} but you're using wrong settings: ${ScriptBinUsed##*/}"
 		fi
     fi
 fi


### PR DESCRIPTION
Works as intended:

![bildschirmfoto 2016-02-28 um 18 15 16](https://cloud.githubusercontent.com/assets/12658961/13380616/c8f91f0c-de47-11e5-9e07-003a87a05a5d.png)

We should enable it for sun8i with the next release (trial balloon for all boards if we later consolidate template contents and filenames: *.bin/*.dtb)