### PR TITLE
Prepare Pine64 addition and Ubuntu Xenial changes

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -173,6 +173,14 @@ if [ "$ARCH" = "armv7l" ]; then
 			create_motd_warning "It seems the image is running on ${ID} but you're using wrong settings: ${ScriptBinUsed##*/}"
 		fi
     fi
+elif [ "$ARCH" = "aarch64" ]; then
+	if [ $HARDWARE = "sun50iw1p1" ]; then
+		if [ $MEMTOTAL -gt 600 ]; then
+			ID="Pine64+"
+		else
+			ID="Pine64"
+		fi
+	fi
 fi
 
 [ -f /proc/device-tree/model ] && read MACHINE </proc/device-tree/model

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -16,7 +16,7 @@
 # Create this file to speed up boot process
 #
 
-# Immediately exit if not called correctly
+# Immediately exit if not called by init system
 if [ "X$1" != "Xstart" ]; then
 	exit 1
 fi
@@ -96,8 +96,9 @@ display_alert() {
 
 autodetect_h3() {
 	# This function adjusts script.bin, hostname and cpufreq settings based on 
-	# /run/machine.id so that two OS images (one built for Orange Pi Plus and one
-	# for the other H3 devices using the internal Ethernet PHY) can be shipped.
+	# /run/machine.id so that two OS images (one built for GbE H3 devices like
+	# Orange Pi Plus or Banana Pi M2+ and one for the other H3 devices using 
+	# the internal Ethernet PHY) can be shipped.
 	#
 	# TODO for mainline kernel: Ship with u-boot debs for all Oranges and install
 	# the right one instead of trying to relink script.bin if detecting mainline
@@ -160,7 +161,14 @@ do_expand_rootfs() {
 	return 0
 }
 
+check_prerequisits() {
+	for needed_tool in fdisk parted partprobe resize2fs ; do
+		which ${needed_tool} >/dev/null 2>&1 || exit 1
+	done
+} # check_prerequisits
+
 main() {
+	check_prerequisits
 	collect_informations
 	display_alert "Force password change upon first login"
 	chage -d 0 root
@@ -185,4 +193,3 @@ main() {
 
 main
 exit 0
-


### PR DESCRIPTION
The _check_prerequisits_ function in _firstrun_ is just to prevent things going wrong when we start to play around with Ubuntu Xenial since there (at least at the moment) some essentials were missing.