### PR TITLE
Copy 8192cu.ko in the kernel-modules directory

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -306,7 +306,8 @@ if [[ -n "$MISC3_DIR" ]]; then
 	#git checkout 0ea77e747df7d7e47e02638a2ee82ad3d1563199
 	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- clean >/dev/null 2>&1
 	(make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- KSRC=$SOURCES/$LINUXSOURCEDIR/ >/dev/null 2>&1)
-	cp *.ko $DEST/cache/sdcard/usr/local/bin
+	cp *.ko $DEST/cache/sdcard/lib/modules/$VER-$LINUXFAMILY/kernel/net/wireless/
+	depmod -b $DEST/cache/sdcard/ $VER-$LINUXFAMILY
 	#cp blacklist*.conf $DEST/cache/sdcard/etc/modprobe.d/
 fi
 


### PR DESCRIPTION
At the moment the module is copied to /usr/local/bin where it does no-one any good; someone in the OPi-forums was just trying to use a dongle that requires this kernel-module. This commit simply copies it in the right place.

I'll see about DKMS.