### PR TITLE
Fix sun8i auto detection on first boot, enable logrotate for armhwinfo

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -208,6 +208,9 @@ detect_board() {
 
 log_hardware_info() {
 	Log=/var/log/armhwinfo.log
+	[ -d /etc/logrotate.d ! -f "/etc/logrotate.d/${0##*/}" ] && \
+		echo -e "${Log} {\n  rotate 12\n  weekly\n  compress\n  missingok\n  notifempty\n}" \
+		> "/etc/logrotate.d/${0##*/}" ; chmod 644 "/etc/logrotate.d/${0##*/}"
 	if [ -f ${Log} ]; then
 		echo -e "\n\n\n$(date) $HARDWARE $ARCH $KERNELID $MACHINE $ID" >>${Log}
 	else
@@ -249,6 +252,7 @@ case $1 in
 		set_io_scheduler &
 
 		# get hardware informations
+		ifconfig | grep -q eth0 || (ifconfig eth0 up ; sleep 1)
 		collect_informations
 		
 		# hardware detection
@@ -257,6 +261,10 @@ case $1 in
 		# display message, log hardware id to file, write log
 		echo -e "[\e[0;32m ok \x1B[0m] Starting ARM hardware info: $ID"
 		echo $ID > /var/run/machine.id
+		if [ $? -ne 0 ]; then
+			# most probably readonly fs. We'll try to warn the user.
+			show_motd_warning "It seems the rootfs is readonly at the moment. Please check your SD card for errors"
+		fi
 		log_hardware_info
 
 		# crash detection, enable verbose logging and disable it at clean shutdown

--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -11,6 +11,7 @@
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 collect_informations() {
+	ifconfig | grep -q eth0 || (ifconfig eth0 up ; sleep 1)
 	TMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 	trap "rm \"${TMPFILE}\" ; exit 0" 0 1 2 3 15
 	dmesg >"${TMPFILE}"
@@ -121,7 +122,6 @@ detect_board() {
 		if [ $HARDWARE = "sun8i" ]; then
 			ID="Orange H3"
 			# 3 or 30 sec user feedback that the board is ready after 1st login with 3.4 kernel
-			# TODO: BPi M3 uses different led colors
 			SwapState="$(grep swap /etc/fstab)"
 			if [ -f /sys/class/leds/green_led/trigger -a "X${SwapState}" != "X" ]; then
 				echo timer >/sys/class/leds/green_led/trigger
@@ -208,7 +208,7 @@ detect_board() {
 
 log_hardware_info() {
 	Log=/var/log/armhwinfo.log
-	[ -d /etc/logrotate.d ! -f "/etc/logrotate.d/${0##*/}" ] && \
+	[ -f "/etc/logrotate.d/${0##*/}" ] || \
 		echo -e "${Log} {\n  rotate 12\n  weekly\n  compress\n  missingok\n  notifempty\n}" \
 		> "/etc/logrotate.d/${0##*/}" ; chmod 644 "/etc/logrotate.d/${0##*/}"
 	if [ -f ${Log} ]; then
@@ -234,7 +234,6 @@ log_hardware_info() {
 	ifconfig >>${Log}
 	echo -e "\n### df:\n" >>${Log}
 	df -h >>${Log}
-	# TODO: logrotate is missing
 } # log_hardware_info
 
 show_motd_warning() {
@@ -252,7 +251,6 @@ case $1 in
 		set_io_scheduler &
 
 		# get hardware informations
-		ifconfig | grep -q eth0 || (ifconfig eth0 up ; sleep 1)
 		collect_informations
 		
 		# hardware detection


### PR DESCRIPTION
Due to 'allow-hotplug' we had the missing PHY information on the 1st boot and therefore wrong board identification. This fixes this (and still speeds up first boot in 'no network' scenarios a lot!). See occurence of 'PHY ID' in http://sprunge.us/SeaK

Also check/warning for readonly rootfs and log rotation enabled for _armhwinfo.log_