### PR TITLE
Automount/eject of USB, fix reboot/shutdown on desktop (Jessie)

### DIFF
--- a/config/boot.cmd
+++ b/config/boot.cmd
@@ -4,7 +4,7 @@ setenv verbosity 7
 else
 setenv verbosity 1
 fi
-setenv bootargs "console=tty1 root=/dev/mmcblk0p1 rootwait rootfstype=ext4 cgroup-enable=memory swapaccount=1 sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_no_mali_mem_reserve sunxi_fb_mem_reserve=16 hdmi.audio=EDID:0 disp.screen0_output_mode=1920x1080p60 panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity}"
+setenv bootargs "console=tty1 root=/dev/mmcblk0p1 rootwait rootfstype=ext4 cgroup_enable=memory swapaccount=1 sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_no_mali_mem_reserve sunxi_fb_mem_reserve=16 hdmi.audio=EDID:0 disp.screen0_output_mode=1920x1080p60 panic=10 consoleblank=0 enforcing=0 loglevel=${verbosity}"
 #--------------------------------------------------------------------------------------------------------------------------------
 # Boot loader script to boot with different boot methods for old and new kernel
 #--------------------------------------------------------------------------------------------------------------------------------

--- a/config/polkit-jessie/plugdev.pkla
+++ b/config/polkit-jessie/plugdev.pkla
@@ -1,0 +1,6 @@
+[Allow Automount]
+Identity=unix-group:plugdev
+Action=org.freedesktop.udisks2.filesystem-mount;org.freedesktop.udisks2.filesystem-mount-system;org.freedesktop.udisks2.filesystem-mount-other-seat;org.freedesktop.udisks2.filesystem-unmount-others;org.freedesktop.udisks2.eject-media;org.freedesktop.udisks2.eject-media-system;org.freedesktop.udisks2.power-off-drive*
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes

--- a/config/polkit-jessie/power.pkla
+++ b/config/polkit-jessie/power.pkla
@@ -1,0 +1,6 @@
+[Allow Desktopstuff]
+Identity=unix-group:sudo
+Action=org.freedesktop.login1.reboot;org.freedesktop.login1.reboot-multiple-session;org.freedesktop.login1.power-off;org.freedesktop.login1.power-off-multiple-sessions;org.freedesktop.login1.suspend;org.freedesktop.login1.suspend-multiple-sessions;org.freedesktop.login1.hibernate;org.freedesktop.login1.hibernate-multiple-sessions
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes

--- a/configuration.sh
+++ b/configuration.sh
@@ -567,7 +567,7 @@ if [[ $BUILD_DESKTOP == yes ]]; then
 		PACKAGE_LIST_DESKTOP="$PACKAGE_LIST_DESKTOP mozo pluma iceweasel icedove"
 		;;
 		jessie)
-		PACKAGE_LIST_DESKTOP="$PACKAGE_LIST_DESKTOP mozo pluma iceweasel libreoffice-writer libreoffice-java-common icedove"
+		PACKAGE_LIST_DESKTOP="$PACKAGE_LIST_DESKTOP mozo pluma iceweasel libreoffice-writer libreoffice-java-common icedove gvfs policykit-1 policykit-1-gnome eject"
 		;;
 		trusty)
 		PACKAGE_LIST_DESKTOP="$PACKAGE_LIST_DESKTOP libreoffice-writer libreoffice-java-common thunderbird firefox gnome-icon-theme-full tango-icon-theme gvfs-backends"

--- a/desktop.sh
+++ b/desktop.sh
@@ -35,6 +35,8 @@ if [[ $RELEASE == "jessie" ]]; then
 	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/armbian*.jpg "$d"	
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /etc/skel/"
 	chroot $DEST/cache/sdcard /bin/bash -c "tar xfz /tmp/jessie-desktop.tgz -C /root/"
+	mkdir -p $DEST/cache/sdcard/etc/polkit-1/localauthority/50-local.d
+	cp $SRC/lib/config/polkit-jessie/*.pkla $DEST/cache/sdcard/etc/polkit-1/localauthority/50-local.d/
 fi
 
 # Ubuntu trusty


### PR DESCRIPTION
There was a typo in boot.cmd that prevented reboot/shutdown/etc. entries in the menu from working. Also, this commit adds dependencies to allow for automounting of USB-storage to work, sets permissions so that users in plugdev-group can mount, unmount, eject and power down USB-storage without always being asked for password, and users in sudo-group can reboot/shutdown/suspend/hibernate without being asked for password.