### PR TITLE
Fixes for board autodetection (Banana Pi legacy)

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -84,9 +84,9 @@ detect_board() {
 	            elif [ "$LEDS" != "" ]; then
 	                ID="Lime 2"
 				elif [ "$WIFIAP6211" != "" ]; then
-	                ID="Banana PRO"            
+	                ID="Banana Pi Pro"            
 	            else
-	                ID="Banana"
+	                ID="Banana Pi"
 	            fi
 	        elif [ "$LEDS" != "" ]; then
 	            ID="Lime"
@@ -196,14 +196,14 @@ detect_board() {
 	if [[ $MACHINE == *LIME2 ]]; then ID="Lime 2"; fi
 	if [[ $MACHINE == *LIME ]]; then ID="Lime"; fi
 	if [[ $MACHINE == *Micro ]]; then ID="Micro"; fi
-	if [[ $MACHINE == *Banana* ]]; then ID="Banana"; fi
+	if [[ $MACHINE == *Banana* ]]; then ID="Banana Pi"; fi
 	if [[ $MACHINE == *Udoo* ]]; then ID="udoo"; fi
 	if [[ $MACHINE == *Lamobo* ]]; then ID="Lamobo R1"; fi
 	if [[ $MACHINE == *Neo* ]]; then ID="Udoo Neo"; fi
 	if [[ $MACHINE == *Cubietruck* ]]; then ID="Cubietruck"; fi
 	if [[ $MACHINE == *Cubieboard* ]]; then ID="Cubieboard"; fi
-	if [[ $MACHINE == *Pro* ]]; then ID="Banana Pro"; fi
-	if [[ $MACHINE == *M2* ]]; then ID="Banana M2"; fi
+	if [[ $MACHINE == *Pro* ]]; then ID="Banana Pi Pro"; fi
+	if [[ $MACHINE == *M2* ]]; then ID="Banana Pi M2"; fi
 } # detect_board
 
 log_hardware_info() {

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -94,16 +94,11 @@ display_alert() {
 	fi
 }
 
-autodetect_a20() {
-sleep 3
-MACHINE="$(tail -n1 /run/machine.id)"
-}
-
-autodetect_h3() {
+autodetect_sunxi() {
 	# This function adjusts script.bin, hostname and cpufreq settings based on 
 	# /run/machine.id so that two OS images (one built for GbE H3 devices like
 	# Orange Pi Plus or Banana Pi M2+ and one for the other H3 devices using 
-	# the internal Ethernet PHY) can be shipped.
+	# the internal Ethernet PHY or Banana Pro vs. Pi) can be shipped.
 	#
 	# TODO for mainline kernel: Ship with u-boot debs for all Oranges and install
 	# the right one instead of trying to relink script.bin if detecting mainline
@@ -121,6 +116,9 @@ autodetect_h3() {
 	ScriptBinName="$(echo "${NEWHOSTNAME}" | sed -e 's/2mini$/2/g' -e 's/plus2$/plus/g').bin"
 	ScriptBinUsed="$(readlink -f "/boot/script.bin")"
 	case ${MACHINE} in
+		"Banana Pi")
+			ln -sf /boot/bin/bananapi.bin /boot/script.bin
+			;;
 		"Orange Pi+"*)
 			if [ "X${ScriptBinName}" != "X${ScriptBinUsed##*/}" ]; then
 				# wrong detection due to disabled Ethernet on 1st boot
@@ -152,13 +150,14 @@ autodetect_h3() {
 			fi
 			;;
 	esac
-	echo "${NEWHOSTNAME}" >/etc/hostname	
-	sed -i "s/orangepih3/${NEWHOSTNAME}/" /etc/hosts
+	echo "${NEWHOSTNAME}" >/etc/hostname
+	sed -i -e "s/^::1         localhost.*/::1         localhost ${NEWHOSTNAME} ip6-localhost ip6-loopback/" \
+		-e "s/^127.0.0.1   localhost.*/127.0.0.1   localhost ${NEWHOSTNAME}/" /etc/hosts
 	[ -f /etc/wicd/wired-settings.conf ] && \
 		sed -i "s/^dhcphostname =.*/dhcphostname = ${NEWHOSTNAME}/" /etc/wicd/wired-settings.conf
-	rm /boot/bin/orangepih3.bin
+	[ -f /boot/bin/orangepih3.bin ] && rm /boot/bin/orangepih3.bin
 	touch /var/run/reboot
-} # autodetect_h3
+} # autodetect_sunxi
 
 do_expand_rootfs() {
 	device="/dev/"$(lsblk -idn -o NAME | grep mmcblk0)
@@ -203,14 +202,10 @@ main() {
 	display_alert "Updating packages"
 	/tmp/create_swap.sh &
 
-	if [ "X${HARDWARE}" = "Xsun8i" ]; then
-		autodetect_h3
+	if [ "X${HARDWARE}" = "Xsun8i" -o "X${HARDWARE}" = "Xsun7i" ]; then
+		autodetect_sunxi
 	fi
 
-	if [ "X${HARDWARE}" = "Xsun7i" ]; then
-                autodetect_a20
-	fi
-	
 	update-rc.d -f firstrun remove >/dev/null 2>&1
 	sed -i 's/allow-hotplug\ eth0/auto eth0/' /etc/network/interfaces.default
 } # main


### PR DESCRIPTION
My new build host is up and running (6-core i7 with 3.x GHz, fast SSD and plenty of RAM). I chose 16.04 LTS and 5.2 and just created and tested a Jessie desktop image for Banana Pi: http://sprunge.us/HZDM

Crazy shit, everything's working out of the box, I connected an USB disk lying around, clicked on a large .mp4 now the Banana is playing 1080p/H.264 smoothly, then I tried suspend to RAM just to realize that we've to define the correct Pin mapping for the power button to be able to resume ;)

In other words: Switching from 14.04 LTS to 16.04 LTS on the build host shouldn't be a problem and also using Linaro's GCC 5.2 :)