### PR TITLE
Greatly speed up firstrun

### DIFF
--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -62,6 +62,7 @@ if [[ "$(apt-cache policy ramlog | grep Installed)" != "" ]]; then
 		fi
 	fi
 fi
+while [ -f /tmp/firstrun_running ]; do sleep 1; done
 if [ -f "/var/run/reboot" ]; then reboot; fi
 rm -f /tmp/create_swap.sh
 EOT
@@ -201,6 +202,7 @@ main() {
 	display_alert "Creating 128Mb emergency swap area"
 	display_alert "SSH keys recreation. One moment please"
 	display_alert "Updating packages"
+	touch /tmp/firstrun_running
 	/tmp/create_swap.sh &
 
 	if [ "X${HARDWARE}" = "Xsun8i" -o "X${HARDWARE}" = "Xsun7i" ]; then
@@ -209,6 +211,7 @@ main() {
 
 	update-rc.d -f firstrun remove >/dev/null 2>&1
 	sed -i 's/allow-hotplug\ eth0/auto eth0/' /etc/network/interfaces.default
+	rm /tmp/firstrun_running
 } # main
 
 main

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -35,7 +35,8 @@ dpkg-reconfigure openssh-server >/dev/null 2>&1
 MEMTOTAL=$(( $(awk -F" " '/^MemTotal/ {print $2}' </proc/meminfo) / 1024 ))
 FREESIZE=\$(df -hm / | awk '/\// {print \$(NF-2)}')
 if [[ ! -f "/var/swap" && "\$FREESIZE" -gt "132" ]]; then
-dd if=/dev/zero of=/var/swap bs=1024 count=131072 status=noxfer >/dev/null 2>&1
+fallocate -l 128M /var/swap >/dev/null 2>&1
+if [ $? -eq 1 ]; then dd if=/dev/zero of=/var/swap bs=1024 count=131072 status=noxfer >/dev/null 2>&1; fi
 chown root:root /var/swap
 chmod 0600 /var/swap
 mkswap /var/swap >/dev/null 2>&1


### PR DESCRIPTION
Use fallocate to create swap instead of dd and only fall back to dd if it fails. fallocate takes < 1 second to create the file, even on very slow media.