### PR TITLE
In case a really slow SD card is used display warning at 3rd boot

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -254,10 +254,32 @@ EOT
 chmod +x /etc/update-motd.d/90-warning
 } # show_motd_warning
 
+check_sd_card_speed() {
+	# function that checks on 3rd boot whether firstrun script made a quick
+	# benchmark when a SD card with 4GB or less capacity has been detected
+	# and displays a warning when random I/O is below some tresholds.
+	RebootCount=$(grep -c '^### df:' /var/log/armhwinfo.log)
+	if [ ${RebootCount} -eq 2 ]; then
+		# check whether iozone data has been collected
+		IozoneResults="$(awk -F" " '/^### quick iozone test/ {print $10"\t"$11}' </var/log/armhwinfo.log)"
+		if [ "X${IozoneResults}" != "X" ]; then
+			set ${IozoneResults}
+			Readspeed=$1
+			Writespeed=$2
+			if [ ${Readspeed} -lt 800 -o ${Writespeed} -lt 400 ]; then
+				show_motd_warning "Your SD card seems to be very slow. Please check performance using armbianmonitor -c"
+			fi
+		fi
+	fi
+} # check_sd_card_speed
+
 case $1 in
 	*start*)
 		# set optimal disk scheduler settings
 		set_io_scheduler &
+		
+		# check sd card speed once
+		check_sd_card_speed &
 
 		# get hardware informations
 		collect_informations


### PR DESCRIPTION
This check will be executed at the 3rd boot and in case `firstrun` detected an SD card with 4 GB or less before a quick&dirty iozone bench has been fired up, now the stored results from `/var/log/armhwinfo.log` will be checked and when below defined tresholds a warning via motd will be displayed.

This check will be accompanied by a small SD card FAQ I'm currently writing sometimes in the future.