### PR TITLE
Fix detection of Beelink X2. 

### DIFF
--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -32,6 +32,7 @@ collect_informations() {
 	INTERUPT=$(grep "eth0" /proc/interrupts)
 	WIFI8189ES=$(lsmod | grep 8189es | grep -v "0 $" | grep -v "0$") # ignore when not loaded
 	WIFIAP6211=$(lsmod | grep ap6211)
+	SPDIF=$(lsmod | grep spdif)
 	read VERSION </proc/version
 } # collect_informations
 
@@ -129,9 +130,9 @@ detect_board() {
 			# 10 or 120 sec user feedback that the board is ready after 1st login with 3.4 kernel
 			SwapState="$(grep swap /etc/fstab)"
 			if [ "X${SwapState}" != "X" ]; then
-				echo heartbeat >/sys/class/leds/*green*/trigger
+				(echo heartbeat >/sys/class/leds/*green*/trigger) 2>/dev/null
 				[ -f "/root/.not_logged_in_yet" ] && BlinkTime=120 || BlinkTime=10
-				(sleep ${BlinkTime} && echo default-on >/sys/class/leds/*green*/trigger) &
+				(sleep ${BlinkTime} && (echo default-on >/sys/class/leds/*green*/trigger) 2>/dev/null) &
 			fi
 	
 			# redistribute USB irqs to dedicated cores
@@ -157,6 +158,8 @@ detect_board() {
 					fi
 					;;
 				esac
+			elif [ "$SPDIF" != "" ]; then
+				ID="Beelink X2"
 			elif [ "$WIFI8189ES" != "" ]; then
 				ID="Orange Pi Lite"
 				echo 8 >/proc/irq/$(awk -F":" "/${WiFi}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
@@ -324,7 +327,7 @@ case $1 in
 		collect_informations
 		if [ $HARDWARE = "sun8i" ]; then
 			# redefine green led to blink until shutdown
-			echo heartbeat >/sys/class/leds/*green*/trigger
+			(echo heartbeat >/sys/class/leds/*green*/trigger) 2>/dev/null 
 		fi
 		;;
 esac


### PR DESCRIPTION
Also, redirect stderr to /dev/null when setting (non-existent) green led.
This armhwinfo was also tested on Orange Pi PC and Orange Pi Plus 2.