### PR TITLE
Fixes for building Orange Pi One on Debian Sid (fixes #321, fixes #319)

### DIFF
--- a/debootstrap-ng.sh
+++ b/debootstrap-ng.sh
@@ -288,7 +288,7 @@ prepare_partitions()
 	parttype[btrfs]=btrfs
 	# parttype[nfs] is empty
 
-	mkopts[ext4]='-q -m 2'
+	mkopts[ext4]='-O ^64bit -q -m 2'
 	mkopts[fat]='-n BOOT'
 	# mkopts[f2fs] is empty
 	# mkopts[btrfs] is empty

--- a/debootstrap-ng.sh
+++ b/debootstrap-ng.sh
@@ -288,7 +288,7 @@ prepare_partitions()
 	parttype[btrfs]=btrfs
 	# parttype[nfs] is empty
 
-	mkopts[ext4]='-O ^64bit -q -m 2'
+	mkopts[ext4]='-O ^64bit,^metadata_csum,uninit_bg -q -m 2'
 	mkopts[fat]='-n BOOT'
 	# mkopts[f2fs] is empty
 	# mkopts[btrfs] is empty

--- a/debootstrap.sh
+++ b/debootstrap.sh
@@ -61,7 +61,7 @@ parted -s $LOOP -- mklabel msdos
 if [ "$BOOTSIZE" -eq "0" ]; then
 	parted -s $LOOP -- mkpart primary ext4  $ROOTSTART"s" -1s
 	partprobe $LOOP
-	mkfs.ext4 -q $LOOP"p1"
+	mkfs.ext4 -O ^64bit -q $LOOP"p1"
 	mount $LOOP"p1" $CACHEDIR/sdcard/
 else
 	parted -s $LOOP -- mkpart primary fat16  $BOOTSTART"s" $BOOTEND"s"

--- a/debootstrap.sh
+++ b/debootstrap.sh
@@ -61,7 +61,7 @@ parted -s $LOOP -- mklabel msdos
 if [ "$BOOTSIZE" -eq "0" ]; then
 	parted -s $LOOP -- mkpart primary ext4  $ROOTSTART"s" -1s
 	partprobe $LOOP
-	mkfs.ext4 -O ^64bit -q $LOOP"p1"
+	mkfs.ext4 -O ^64bit,^metadata_csum,uninit_bg -q $LOOP"p1"
 	mount $LOOP"p1" $CACHEDIR/sdcard/
 else
 	parted -s $LOOP -- mkpart primary fat16  $BOOTSTART"s" $BOOTEND"s"

--- a/makeboarddeb.sh
+++ b/makeboarddeb.sh
@@ -120,7 +120,12 @@ create_board_package (){
 	if [[ $LINUXCONFIG == *sun* ]] ; then
 		if [[ $BRANCH != next ]]; then
 			# add soc temperature app
-			arm-linux-gnueabihf-gcc $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/local/bin/sunxi_tp_temp
+			local codename=$(lsb_release -sc)
+			if [[ -z $codename || "sid" == *"$codename"* ]]; then
+				arm-linux-gnueabihf-gcc-5 $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/local/bin/sunxi_tp_temp
+			else
+				arm-linux-gnueabihf-gcc $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/local/bin/sunxi_tp_temp
+			fi
 		fi
 
 		# lamobo R1 router switch config


### PR DESCRIPTION
Below 3 patches contain fixes that I had to apply to build bootable Orage Pi One image on Debian Sid.