### PR TITLE
Finalized move away from broken auto detection

### DIFF
--- a/config/boards/bananapipro.conf
+++ b/config/boards/bananapipro.conf
@@ -1,4 +1,4 @@
-# A20 dual core 1Gb SoC
+# A20 dual core 1GB SoC WiFi
 BOARD_NAME="Banana Pi Pro"
 LINUXFAMILY=sun7i
 BOOTCONFIG=Bananapro_defconfig

--- a/config/fex/nanopim1.fex
+++ b/config/fex/nanopim1.fex
@@ -1,6 +1,6 @@
 [product]
 version = "100"
-machine = "nanopi-h3"
+machine = "nanopi-m1"
 
 [platform]
 debug_mode = 1
@@ -243,7 +243,7 @@ gpio_pin_19 = port:PG07<1><default><default><0>
 
 [leds_para]
 leds_used = 1
-green_led = port:PL10<1><default><default><0>
+green_led = port:PL10<1><default><default><1>
 green_led_active_low = 0
 blue_led = port:PA10<1><default><default><0>
 blue_led_active_low = 0
@@ -251,12 +251,12 @@ blue_led_active_low = 0
 [ths_para]
 ths_used = 1
 ths_trip1_count = 6
-ths_trip1_0 = 70
+ths_trip1_0 = 75
 ths_trip1_1 = 80
 ths_trip1_2 = 85
 ths_trip1_3 = 90
 ths_trip1_4 = 95
-ths_trip1_5 = 100
+ths_trip1_5 = 105
 ths_trip1_6 = 0
 ths_trip1_7 = 0
 ths_trip1_0_min = 0
@@ -270,19 +270,22 @@ ths_trip1_3_max = 4
 ths_trip1_4_min = 4
 ths_trip1_4_max = 5
 ths_trip1_5_min = 5
-ths_trip1_5_max = 5
+ths_trip1_5_max = 7
 ths_trip1_6_min = 0
 ths_trip1_6_max = 0
 ths_trip2_count = 1
 ths_trip2_0 = 105
 
 [cooler_table]
-cooler_count = 5
+cooler_count = 8
 cooler0 = "1200000 4 4294967295 0"
-cooler1 = "1008000 4 4294967295 0"
-cooler2 = "816000 4 4294967295 0"
-cooler3 = "648000 2 4294967295 0"
-cooler4 = "480000 1 4294967295 0"
+cooler1 = "912000 4 4294967295 0"
+cooler2 = "768000 4 4294967295 0"
+cooler3 = "648000 4 4294967295 0"
+cooler4 = "480000 4 4294967295 0"
+cooler5 = "480000 3 4294967295 0"
+cooler6 = "480000 2 4294967295 0"
+cooler7 = "480000 1 4294967295 0"
 
 [nand0_para]
 nand_support_2ch = 0
@@ -688,6 +691,30 @@ ir_tx = port:PH07<2><default><default><default>
 [ls_para]
 ls_used = 0
 
+;----------------------------------------------------------------------------------
+; dvfs voltage-frequency table configuration
+;
+; pmuic_type:0:none, 1:gpio, 2:i2c
+; pmu_gpio0: gpio config.
+; pmu_levelx: 0~9999: voltage(mV), 10000~90000:gpio0 state. voltage form high to low.
+;
+; extremity_freq(Hz): cpu extremity frequency when run benckmark or demo apk
+;                     1536MHz@1500mV with radiator, 1296MHz@1340mV without radiator
+; max_freq: cpu maximum frequency, based on Hz, can not be more than 1200MHz
+; min_freq: cpu minimum frequency, based on Hz, can not be less than 60MHz
+;
+; LV_count: count of LV_freq/LV_volt, must be < 16
+;
+; LV1: core vdd is 1.50v if cpu frequency is (1296Mhz,  1536Mhz]
+; LV2: core vdd is 1.34v if cpu frequency is (1200Mhz,  1296Mhz]
+; LV3: core vdd is 1.32v if cpu frequency is (1008Mhz,  1200Mhz]
+; LV4: core vdd is 1.20v if cpu frequency is (816Mhz,   1008Mhz]
+; LV5: core vdd is 1.10v if cpu frequency is (648Mhz,    816Mhz]
+; LV6: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+; LV7: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+; LV8: core vdd is 1.04v if cpu frequency is (0Mhz,      648Mhz]
+;
+;----------------------------------------------------------------------------------
 [dvfs_table]
 pmuic_type = 1
 pmu_gpio0 = port:PL06<1><1><2><1>
@@ -700,7 +727,7 @@ LV1_freq = 1200000000
 LV1_volt = 1300
 LV2_freq = 1008000000
 LV2_volt = 1300
-LV3_freq = 816000000
+LV3_freq = 912000000
 LV3_volt = 1100
 LV4_freq = 648000000
 LV4_volt = 1100
@@ -793,3 +820,5 @@ mali_extreme_vol = 1400
 w1_used = 1
 gpio = 20
 
+[corekeeper]
+corekeeper_enabled = 1

--- a/config/fex/orangepilite.fex
+++ b/config/fex/orangepilite.fex
@@ -352,7 +352,7 @@ pwm_positive = port:PA05<3><0><default><default>
 ;       If set gamc_phy to use = 2
 
 [gmac0]
-gmac_used = 2
+gmac_used = 0
 gmac_power1 =
 
 [csi0]

--- a/scripts/armhwinfo
+++ b/scripts/armhwinfo
@@ -10,7 +10,7 @@
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-collect_informations() {
+collect_information() {
 	ifconfig | grep -q eth0 || (ifconfig eth0 up ; sleep 2)
 	TMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 	trap "rm \"${TMPFILE}\" ; exit 0" 0 1 2 3 15
@@ -30,11 +30,12 @@ collect_informations() {
 	GL830=$(lsusb | grep -i "05e3:0718")
 	SWITCH=$(grep "BCM53125" "${TMPFILE}")
 	INTERUPT=$(grep "eth0" /proc/interrupts)
-	WIFI8189ES=$(lsmod | grep 8189es | grep -v "0 $" | grep -v "0$") # ignore when not loaded
+	WIFI8189ES=$(lsmod | grep 8189es)
+	WIFI8189FS=$(lsmod | grep 8189fs)
 	WIFIAP6211=$(lsmod | grep ap6211)
 	SPDIF=$(lsmod | grep spdif)
 	read VERSION </proc/version
-} # collect_informations
+} # collect_information
 
 set_io_scheduler() {
 	for i in $( lsblk -idn -o NAME ); do
@@ -138,7 +139,10 @@ detect_board() {
 			# redistribute USB irqs to dedicated cores
 			echo 2 >/proc/irq/$(awk -F":" "/${USB1}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 			echo 4 >/proc/irq/$(awk -F":" "/${USB2}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			if [ "$TERMINUS" != "" ]; then
+			if [ -f /sys/class/leds/*blue*/trigger ] ; then
+				ID="NanoPi M1"
+				echo 8 >/proc/irq/$(awk -F":" "/${USB3}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			elif [ "$TERMINUS" != "" ]; then
 				# Ethernet irqs on cpu3
 				echo 8 >/proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 				ID="Orange Pi+"
@@ -160,9 +164,17 @@ detect_board() {
 				esac
 			elif [ "$SPDIF" != "" ]; then
 				ID="Beelink X2"
-			elif [ "$WIFI8189ES" != "" ]; then
-				ID="Orange Pi Lite"
-				echo 8 >/proc/irq/$(awk -F":" "/${WiFi}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			elif [ "$WIFI8189FS" != "" ]; then
+				if [ $MEMTOTAL -gt 1200 ]; then
+					ID="Orange Pi+ 2E"
+					echo 8 >/proc/irq/$(awk -F":" "/${GbE}// {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+				elif [ $MEMTOTAL -gt 600 ]; then
+					ID="Orange Pi PC Plus"
+					echo 8 >/proc/irq/$(awk -F":" "/${USB3}// {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+				else
+					ID="Orange Pi Lite"
+				i	echo 8 >/proc/irq/$(awk -F":" "/${WiFi}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+				fi
 			elif [ $MEMTOTAL -gt 600 ]; then
 				case ${SUN8IPHY} in
 				00441400*)
@@ -292,7 +304,7 @@ case $1 in
 		check_sd_card_speed &
 
 		# get hardware informations
-		collect_informations
+		collect_information
 		
 		# hardware detection
 		detect_board

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -64,7 +64,7 @@ rm -f /tmp/create_swap.sh
 EOT
 chmod +x /tmp/create_swap.sh
 
-collect_informations() {
+collect_information() {
 	# get some info about the board
 	CURKERNE=$(uname -r | sed 's/\([0-9]\+\.[0-9]\+\)\..*/\1/')
 	DISTRIBUTION=$(lsb_release -cs)
@@ -90,7 +90,7 @@ collect_informations() {
 			rootfstype=$2
 			;;
 	esac
-} # collect_informations
+} # collect_information
 
 display_alert() {
 	if [ "${DISTRIBUTION}" == "wheezy" ]; then
@@ -102,15 +102,15 @@ display_alert() {
 	fi
 }
 
-autodetect_sunxi() {
+adjust_sunxi_settings() {
 	# trigger red or blue LED as user feedback
 	echo heartbeat >/sys/class/leds/*red*/trigger 2>/dev/null || echo heartbeat >/sys/class/leds/*blue*/trigger 2>/dev/null	
 	[ -f /etc/wicd/wired-settings.conf ] && \
-		sed -i "s/^dhcphostname =.*/dhcphostname = ${NEWHOSTNAME}/" /etc/wicd/wired-settings.conf && \
+		read HOSTNAME </etc/hostname
+		sed -i "s/^dhcphostname =.*/dhcphostname = ${HOSTNAME}/" /etc/wicd/wired-settings.conf && \
 		sed -i "s/wpa_driver =.*/wpa_driver = none/" /etc/wicd/manager-settings.conf
 	[ -f /boot/bin/orangepih3.bin ] && rm /boot/bin/orangepih3.bin
-	touch /var/run/reboot
-} # autodetect_sunxi
+} # adjust_sunxi_settings
 
 do_expand_rootfs() {
 	# get device node for boot media
@@ -177,7 +177,7 @@ do_expand_rootfs() {
 		update-rc.d resize2fs defaults >/dev/null 2>&1 
 	fi
 	return 0
-}
+} # do_expand_rootfs
 
 check_prerequisits() {
 	for needed_tool in fdisk parted partprobe resize2fs ; do
@@ -187,7 +187,7 @@ check_prerequisits() {
 
 main() {
 	check_prerequisits
-	collect_informations
+	collect_information
 
 	if [[ "$rootfstype" == "ext4" && ! -f "/root/.no_rootfs_resize" ]]; then
 		display_alert "Resizing root filesystem."
@@ -201,7 +201,7 @@ main() {
 	/tmp/create_swap.sh &
 
 	if [ "X${HARDWARE}" = "Xsun8i" -o "X${HARDWARE}" = "Xsun7i" ]; then
-		autodetect_sunxi
+		adjust_sunxi_settings
 	fi
 
 	# pine64 temp workaround


### PR DESCRIPTION
One last attempt to do some sort auf (broken) auto detection in `armhwinfo` (tested with Lite, PC, PC Plus, BPi M2+ and OPi Plus 2E) before we move the whole system to the [new approach](https://github.com/igorpecovnik/lib/issues/231#issuecomment-219516025) @zador-blood-stained proposed.

With the new legacy kernel there's something 'wrong' with the leds anyway (red always on when kernel loads) and another things I noticed when using 16.04 LTS as distro target:

    Ubuntu 16.04 LTS bananapim2plus ttyS0
    
    bananapim2plus login: root
    Password: 
    You are required to change your password immediately (root enforced)
    Changing password for root.
    (current) UNIX password: 
    Enter new UNIX password: 
    Retype new UNIX password: 
    Traceback (most recent call last):
      File "/etc/update-motd.d/40-updates", line 25, in <module>
        import apt_pkg
    ImportError: No module named apt_pkg
    run-parts: /etc/update-motd.d/40-updates exited with return code 1

Apart from that with these fixes we should be able to release new images that do not depend on auto detection any more. In case users connect an USB hub then they'll run only into cosmetical hassles (wrong machine.id and maybe not ideal IRQ distribution).