### PR TITLE
Never resize rootfs to whole card size, prepare BT on BPi M2+

### DIFF
--- a/config/boards/bananapim2plus.conf
+++ b/config/boards/bananapim2plus.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Banana Pi M2+"
 LINUXFAMILY=sun8i
 BOOTCONFIG=Sinovoip_BPI_M2_plus_defconfig
-MODULES="#gpio-sunxi #w1-sunxi #w1-gpio #w1-therm bcmdhd"
+MODULES="#gpio-sunxi #w1-sunxi #w1-gpio #w1-therm hci_uart rfcomm hidp bcmdhd"
 MODULES_NEXT="brcmfmac"
 CPUMIN=240000
 CPUMAX=1200000

--- a/config/fex/bananapim2plus.fex
+++ b/config/fex/bananapim2plus.fex
@@ -269,10 +269,10 @@ uart_rx         = port:PA05<2><1><default><default>
 uart_used       = 1
 uart_port       = 1
 uart_type       = 4
-uart_tx         = port:PG06<2><1><default><default>
-uart_rx         = port:PG07<2><1><default><default>
-uart_rts        = port:PG08<2><1><default><default>
-uart_cts        = port:PG09<2><1><default><default>
+uart_tx         = port:PG06<3><1><default><default>
+uart_rx         = port:PG07<3><1><default><default>
+uart_rts        = port:PG08<3><1><default><default>
+uart_cts        = port:PG09<3><1><default><default>
 
 [uart2]
 uart_used       = 1

--- a/scripts/firstrun
+++ b/scripts/firstrun
@@ -103,9 +103,13 @@ display_alert() {
 }
 
 adjust_sunxi_settings() {
-
-	# set some mac address to wifi	
+	# set some mac address for wifi	
 	[[ "$(lsmod | grep 8189fs)" != "" ]] && printf 'options 8189fs rtw_initmac=00:60:2F:%02X:%02X:%02X\n' $[RANDOM%256] $[RANDOM%256] $[RANDOM%256] > /etc/modprobe.d/8189fs.conf
+
+	# set some mac address for BT
+	[[ "$(lsmod | grep bcmdhd)" != "" ]] && \
+		(MACADDR=$(printf '43:29:B1:%02X:%02X:%02X\n' $[RANDOM%256] $[RANDOM%256] $[RANDOM%256]) ; \
+		sed -i "s/^MAC_ADDR=.*/MAC_ADDR=${MACADDR}/" /etc/default/brcm40183)
 	
 	# trigger red or blue LED as user feedback
 	echo heartbeat >/sys/class/leds/*red*/trigger 2>/dev/null || echo heartbeat >/sys/class/leds/*blue*/trigger 2>/dev/null	
@@ -149,6 +153,11 @@ do_expand_rootfs() {
 				;;
 		esac
 	else
+		# Unattended mode. We run a q&d benchmark to be able to identify cards way too slow easily
+		cd /root
+		echo -e "\n### quick iozone test:\c" >>/var/log/armhwinfo.log
+		iozone -e -I -a -s 1M -r 4k -i 0 -i 1 -i 2 | grep '^            1024' | sed 's/            1024      //' >>/var/log/armhwinfo.log
+
 		# check device capacity. If 4GB or below do not use whole card but leave a 5% spare area
 		# to help older cards with wear leveling and garbage collection. In case this reduced card
 		# capacity is less than the actual image capacity this is a clear sign that someone wants
@@ -156,13 +165,17 @@ do_expand_rootfs() {
 		# should know what he's doing)
 		CAPACITY=$(parted ${DEVICE} unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", \$2 / ( 1024 / \$4 ))}")
 		if [ ${CAPACITY} -lt 4000000 ]; then
-			# we also run a q&d benchmark to be able to identify cards way too slow easily
-			cd /root
-			echo -e "\n### quick iozone test:\c" >>/var/log/armhwinfo.log
-			iozone -e -I -a -s 1M -r 4k -i 0 -i 1 -i 2 | grep '^            1024' | sed 's/            1024      //' >>/var/log/armhwinfo.log
 			SPAREAREA=$(( ${CAPACITY} / 20000 ))
 			LASTSECTOR=$(parted ${DEVICE} unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {print \$2 - (${SPAREAREA} * 1024 * ( 1024 / \$4 ))}")
 			if [ ${LASTSECTOR} -lt ${PARTEND} ]; then unset LASTSECTOR ; fi
+		elif [ ${CAPACITY} -lt 8000000 ]; then
+			# Leave 2 percent unpartitioned
+			LASTSECTOR=$(( 32 * $(parted ${DEVICE} unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 98 / 3200))}") -1 ))
+			if [ ${LASTSECTOR} -lt ${PARTEND} ]; then unset LASTSECTOR ; fi
+		else
+			# Leave 1 percent unpartitioned
+                        LASTSECTOR=$(( 32 * $(parted ${DEVICE} unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 99 / 3200))}") -1 ))
+                        if [ ${LASTSECTOR} -lt ${PARTEND} ]; then unset LASTSECTOR ; fi
 		fi
 	fi
 


### PR DESCRIPTION
On SD cards with 4GB or less leave 5 percent unused, on 8GB cards 2 percent and on larger cards 1 percent (implementing request for enhancement #343 to help cloning the installation media). Preparing BT on BPi M2+