### PR TITLE
NanoPi M1 has to use the same thermal configuration / cooler_table as Banana Pi M2+ (same overheating problem)

### DIFF
--- a/config/fex/nanopim1.fex
+++ b/config/fex/nanopim1.fex
@@ -250,15 +250,15 @@ blue_led_active_low = 0
 
 [ths_para]
 ths_used = 1
-ths_trip1_count = 6
-ths_trip1_0 = 75
-ths_trip1_1 = 80
-ths_trip1_2 = 85
-ths_trip1_3 = 90
-ths_trip1_4 = 95
-ths_trip1_5 = 105
-ths_trip1_6 = 0
-ths_trip1_7 = 0
+ths_trip1_count = 8
+ths_trip1_0 = 65
+ths_trip1_1 = 70
+ths_trip1_2 = 75
+ths_trip1_3 = 80
+ths_trip1_4 = 85
+ths_trip1_5 = 90
+ths_trip1_6 = 95
+ths_trip1_7 = 105
 ths_trip1_0_min = 0
 ths_trip1_0_max = 1
 ths_trip1_1_min = 1
@@ -268,24 +268,33 @@ ths_trip1_2_max = 3
 ths_trip1_3_min = 3
 ths_trip1_3_max = 4
 ths_trip1_4_min = 4
-ths_trip1_4_max = 5
-ths_trip1_5_min = 5
-ths_trip1_5_max = 7
-ths_trip1_6_min = 0
-ths_trip1_6_max = 0
+ths_trip1_4_max = 6
+ths_trip1_5_min = 6
+ths_trip1_5_max = 8
+ths_trip1_6_min = 8
+ths_trip1_6_max = 10
+ths_trip1_7_min = 0
+ths_trip1_7_max = 0
 ths_trip2_count = 1
 ths_trip2_0 = 105
 
+;----------------------------------------------------------------------------------
+;cooler_table  cooler_count <=32
+;----------------------------------------------------------------------------------
+
 [cooler_table]
-cooler_count = 8
+cooler_count = 11
 cooler0 = "1200000 4 4294967295 0"
-cooler1 = "912000 4 4294967295 0"
-cooler2 = "768000 4 4294967295 0"
-cooler3 = "648000 4 4294967295 0"
-cooler4 = "480000 4 4294967295 0"
-cooler5 = "480000 3 4294967295 0"
-cooler6 = "480000 2 4294967295 0"
-cooler7 = "480000 1 4294967295 0"
+cooler1 = "1008000 4 4294967295 0"
+cooler2 = "816000 4 4294967295 0"
+cooler3 = "720000 4 4294967295 0"
+cooler4 = "648000 4 4294967295 0"
+cooler5 = "480000 4 4294967295 0"
+cooler6 = "312000 4 4294967295 0"
+cooler7 = "240000 4 4294967295 0"
+cooler8 = "240000 3 4294967295 0"
+cooler9 = "240000 2 4294967295 0"
+cooler10 = "240000 1 4294967295 0"
 
 [nand0_para]
 nand_support_2ch = 0


### PR DESCRIPTION
See [this topic](http://forum.armbian.com/index.php/topic/1322-testers-wanted-testing-dram-reliability-on-bpi-m2-and-nanopi-m1/) and especially [this post I made](http://forum.armbian.com/index.php/topic/1322-testers-wanted-testing-dram-reliability-on-bpi-m2-and-nanopi-m1/#entry10205) .

With this change at least the board does not crash under high load.