### PR TITLE
OrangePi Lite - Turn on Status LED using boot.cmd

### DIFF
--- a/boards.sh
+++ b/boards.sh
@@ -49,7 +49,10 @@ install_board_specific (){
 	else
 		cp $SRC/lib/config/boot.cmd $CACHEDIR/sdcard/boot/boot.cmd
 		# orangepi h3 temp exceptions
-		[[ $LINUXFAMILY == "sun8i" ]] && sed -i -e '1s/^/gpio set PL10\ngpio set PG11\nsetenv machid 1029\nsetenv bootm_boot_mode sec\n/' \
+                # orangepilite uses Power LED on PL10 - Will fail to turn on
+                # orangepilite uses Power LED on PG11 - Is used for camera pin CSI_EN
+                # orangepilite uses Status LED on PA15 - Turn on "Status LED" early
+		[[ $LINUXFAMILY == "sun8i" ]] && sed -i -e '1s/^/gpio set PL10\ngpio set PG11\ngpio set PA15\nsetenv machid 1029\nsetenv bootm_boot_mode sec\n/' \
 			-e 's/\ disp.screen0_output_mode=1920x1080p60//' -e 's/\ hdmi.audio=EDID:0//' $CACHEDIR/sdcard/boot/boot.cmd
 		# let's prepare for old kernel too
 		#chroot $CACHEDIR/sdcard /bin/bash -c \


### PR DESCRIPTION
First: this patch is untested, however it it based on the notes below.

Notes:

Prior to modifications no lights turned on (PG11 is CSI_EN Camera on OrangePi Lite)

On my board, turning on the power LED D7/PL10 early does not work as shown in the below warning.

```
## Executing script at 43100000
gpio: pin PL10 (gpio 298) value is 1
   Warning: value of pin is still 0 <- Power LED remains off
gpio: pin PG11 (gpio 203) value is 1
```


Modifying /boot.cmd and recompiling it to boot.scr successfully turned on the Status LED early in the boot process.

```
diff --git a/boot.cmd b/boot.cmd2
index e91b701..e8d51c7 100644
--- a/boot.cmd
+++ b/boot.cmd2
@@ -1,5 +1,5 @@
 gpio set PL10
-gpio set PG11
+gpio set PA15
```

FYI on my board, the status LED D6/PA15 is Red (not green) - But it is the correct LED.

```
Found U-Boot script /boot/boot.scr
2452 bytes read in 192 ms (11.7 KiB/s)
## Executing script at 43100000
gpio: pin PL10 (gpio 298) value is 1
   Warning: value of pin is still 0
gpio: pin PA15 (gpio 15) value is 1 <- Status LED On
190 bytes read in 135 ms (1000 Bytes/s)
```

Seemed no hurt in trying to bit twiddle all 3 ports, so why not simply add PA15 and cover all bases?




