### PR TITLE
50unattended-upgrades: "CODENAME-Security" doesn't provide Security patches under Debian Jessie #337

### DIFF
--- a/scripts/50unattended-upgrades
+++ b/scripts/50unattended-upgrades
@@ -1,5 +1,5 @@
 Unattended-Upgrade::Origins-Pattern {
       "o=ORIGIN,n=CODENAME";
       "o=ORIGIN,n=CODENAME-updates";
-      "o=ORIGIN,n=CODENAME,l=CODENAME-Security";
+      "o=ORIGIN,n=CODENAME,l=ORIGIN-Security";
 };


### PR DESCRIPTION
Corrected to use "macro" name ORIGIN to specify which Security repository to use.
Verified change by rebuilding OrangePi Plus image and running on OrangePi Plus 2E.
