### PR TITLE
Allow digits in user names

### DIFF
--- a/scripts/check_first_login.sh
+++ b/scripts/check_first_login.sh
@@ -5,7 +5,7 @@ if [ "$-" != "${-#*i}" ]; then
 		echo -e "\n\e[0;31mThank you for choosing Armbian! Support: \e[1m\e[39mwww.armbian.com\x1B[0m\n"
 		echo -e "Creating new account. Please provide a username (eg. your forename): \c"
 		read username
-		RealUserName="$(echo "${username}" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alpha:]')"
+		RealUserName="$(echo "${username}" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]')"
 		adduser ${RealUserName} || reboot
 		for additionalgroup in sudo netdev audio video dialout plugdev bluetooth ; do
 			usermod -aG ${additionalgroup} ${RealUserName} 2>/dev/null


### PR DESCRIPTION
When I tried to create my default user name "r2d2" it was automatically changed to "rd". Change the script to allow digits in usernames.
