### PR TITLE
Add a generic how to to the hardware feature documentation

### DIFF
--- a/documentation/Enabling_hardware_features.md
+++ b/documentation/Enabling_hardware_features.md
@@ -5,6 +5,24 @@ Some boards require some manual configuration to turn on/off certain features
 
 In some cases, the procedure is "less than obvious", so we document some basic examples here.
 
+# Generic howto for Allwinner devices
+
+## Legacy or Vanilla kernel ?
+
+Many Armbian images come in two flavours : Legacy (using an older kernel version) and Vanilla (up-to-date kernel). Depending on kernel version, the procedure to enable/disable features is not the same :
+ * Legacy kernel : FEX
+ * Vanilla kernel : DT (Device Tree)
+
+## What flavour am I using ?
+
+Best way to know is by checking your kernel version :
+
+```
+root@bananapipro:~# uname -a
+Linux bananapipro 4.5.2-sunxi #11 SMP Thu Apr 28 21:53:25 CEST 2016 armv7l GNU/Linux
+```
+
+In this example the kernel version is 4.5.2 so you can use DT to tweak some settings. If you get a kernel version 3.X then you'll be certainly using FEX.
 
 # H3 based Orange Pi, legacy kernel
 


### PR DESCRIPTION
I know this is far from complete, but my goal is to add a more generic introduction to this documentation with basic fex usage, dt usage. 

This should make it easier to add new items and avoid duplication.

Let me know what you think about it