### PR TITLE
Update the FEX handling in the documentation

### DIFF
--- a/documentation/Enabling_hardware_features.md
+++ b/documentation/Enabling_hardware_features.md
@@ -22,7 +22,61 @@ root@bananapipro:~# uname -a
 Linux bananapipro 4.5.2-sunxi #11 SMP Thu Apr 28 21:53:25 CEST 2016 armv7l GNU/Linux
 ```
 
-In this example the kernel version is 4.5.2 so you can use DT to tweak some settings. If you get a kernel version 3.X then you'll be certainly using FEX.
+In this example the kernel version is 4.5.2 so you can use DT to tweak some settings. If you get a kernel version 3.X then you'll be certainly using FEX like on an Orange Pi Plus 2E :
+
+```
+root@orangepiplus2e:~# uname -a
+Linux orangepiplus2e 3.4.112-sun8i #10 SMP PREEMPT Wed Jun 1 19:43:08 CEST 2016 armv7l GNU/Linux
+```
+
+## FEX
+
+### Which file should I edit
+
+Armbian embed a lot of BIN files, but a symlink point to the one in use :
+
+```
+root@orangepiplus2e:~# ls -la /boot/script.bin
+lrwxrwxrwx 1 root root 22 Jun  1 20:30 /boot/script.bin -> bin/orangepiplus2e.bin
+```
+
+### Updating a FEX
+
+You may need to use `sudo` with all the following commands.
+
+The whole process won't overwrite any of your files. If you're paranoid, you can make a proper backup of your BIN file :
+
+```
+cp /boot/script.bin /boot/bin/script.bin.backup
+```
+
+Then you can decompile your BIN into a FEX :
+
+```
+bin2fex /boot/script.bin /tmp/custom.fex
+```
+
+Finally you can edit your FEX file with your favorite text editor and compile it back to a BIN :
+
+```
+fex2bin /tmp/custom.fex /boot/bin/custom.bin
+```
+
+The last step is to change the symlink to use your custom BIN :
+
+```
+ln -sf /boot/bin/custom.bin /boot/script.bin
+```
+
+## Device Tree
+
+### Which file should I edit
+
+I use the following command and try to guess which file to use in `/boot/dtb/` :
+
+```
+cat /proc/device-tree/model
+```
 
 # H3 based Orange Pi, legacy kernel
 


### PR DESCRIPTION
Here is the followup of yesterday's commit. So far I've only added a new generic documentation on FEX handling. The way I show is not exactly the same as what @pctj101 did. Let me know what you prefer ?

Next commit will alter the UART paragraph to make use of what I added.

I've started documenting the device tree but as I wrote it I found out that I knew less stuff than I thought. I'll certainly need help here especially on how to know which DTB file to edit.