### PR TITLE
patch to enable eMMC in OrangePiPlus2E

### DIFF
--- a/patch/kernel/sun8i-dev/patch-for-eMMC-sun8i-h3-orangepi-pc-dts.patch
+++ b/patch/kernel/sun8i-dev/patch-for-eMMC-sun8i-h3-orangepi-pc-dts.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+index 82b3fe9..3df09e8 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+@@ -200,6 +200,15 @@
+ 	status = "okay";
+ };
+ 
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v0>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
++}; 
++
+ &ohci1 {
+ 	status = "okay";
+ };


### PR DESCRIPTION
Hi Igor,
I've decide to figure out why eMMC wasn't visible in 4.6.x, and figure out that mmc2 wasn't defined yet.
It worked, and suddently I saw that Xunlong had already pushed an Android image on my OrangePi-Plus2E, so I'm backing it up right now !
I will try to install Armbian from SD to eMMC later, I don't even know yet if eMMC will be bootable or requires some other changes, but at least it is a beginning ...
