### PR TITLE
Tiny typo fix in variable naming

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -11,7 +11,7 @@
 
 # common options
 
-REVISION="5.17$SUBREVISON" # all boards have same revision
+REVISION="5.17$SUBREVISION" # all boards have same revision
 ROOTPWD="1234" # Must be changed @first login
 MAINTAINER="Igor Pecovnik" # deb signature
 MAINTAINERMAIL="igor.pecovnik@****l.com" # deb signature


### PR DESCRIPTION
Assumed _$SUBREVISON_ to be a typo.