### PR TITLE
add additional u-boot workaround for h3 SMP on mainline

### DIFF
--- a/config/sources/sunxi_common.inc
+++ b/config/sources/sunxi_common.inc
@@ -30,6 +30,9 @@ install_boot_script()
 	cp $SRC/lib/config/bootscripts/boot-sunxi.cmd $CACHEDIR/sdcard/boot/boot.cmd
 
 	# orangepi h3 temp exceptions
-	[[ $LINUXFAMILY == sun8i ]] && sed -i -e '1s/^/gpio set PL10\ngpio set PG11\nsetenv machid 1029\nsetenv bootm_boot_mode sec\n/' \
+	# u-boot default is nonsec.  Legacy requires sec, Mainline requires nonsec for SMP
+	H3_BOOT_MODE="sec"
+	[[ $BRANCH != default ]] && H3_BOOT_MODE="nonsec"
+	[[ $LINUXFAMILY == sun8i ]] && sed -i -e "1s/^/gpio set PL10\ngpio set PG11\nsetenv machid 1029\nsetenv bootm_boot_mode $H3_BOOT_MODE\n/" \
 		-e 's/\ disp.screen0_output_mode=1920x1080p60//' -e 's/\ hdmi.audio=EDID:0//' $CACHEDIR/sdcard/boot/boot.cmd
 }


### PR DESCRIPTION
patch for #408 

Simple patch for now.. really should just allow u-boot default to propagate through for mainline

forum [discussion here](http://forum.armbian.com/index.php/topic/1599-408-temp-h3-u-boot-setting-causing-mainline-to-not-have-smp-enabled/)