### PR TITLE
Fix missing links in previous version of add_missing_UARTs_I2Cs_SPI_for-H3.patch

### DIFF
--- a/patch/kernel/sun8i-dev/add_missing_UARTs_I2Cs_SPI_for-H3.patch
+++ b/patch/kernel/sun8i-dev/add_missing_UARTs_I2Cs_SPI_for-H3.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index 8e7d38c..106204e 100644
+index 8e7d38c..06aa68c 100644
 --- a/arch/arm/boot/dts/sun8i-h3.dtsi
 +++ b/arch/arm/boot/dts/sun8i-h3.dtsi
 @@ -48,6 +48,11 @@
@@ -114,7 +114,7 @@ index 8e7d38c..106204e 100644
  			mmc0_pins_a: mmc0@0 {
  				allwinner,pins = "PF0", "PF1", "PF2", "PF3",
  						 "PF4", "PF5";
-@@ -699,6 +790,67 @@
+@@ -699,6 +790,77 @@
  			status = "disabled";
  		};
  
@@ -122,6 +122,8 @@ index 8e7d38c..106204e 100644
 +			compatible = "allwinner,sun6i-a31-i2c";
 +			reg = <0x01c2ac00 0x400>;
 +			interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c0_pins_a>;
 +			clocks = <&bus_gates 96>;
 +			resets = <&apb2_rst 0>;
 +			status = "disabled";
@@ -133,6 +135,8 @@ index 8e7d38c..106204e 100644
 +			compatible = "allwinner,sun6i-a31-i2c";
 +			reg = <0x01c2b000 0x400>;
 +			interrupts = <GIC_SPI 7 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c2_pins_a>;
 +			clocks = <&bus_gates 97>;
 +			resets = <&apb2_rst 1>;
 +			status = "disabled";
@@ -144,6 +148,8 @@ index 8e7d38c..106204e 100644
 +			compatible = "allwinner,sun6i-a31-i2c";
 +			reg = <0x01c2b400 0x400>;
 +			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c2_pins_a>;
 +			clocks = <&bus_gates 98>;
 +			resets = <&apb2_rst 2>;
 +			status = "disabled";
@@ -155,6 +161,8 @@ index 8e7d38c..106204e 100644
 +			compatible = "allwinner,sun6i-a31-spi";
 +			reg = <0x01c68000 0x1000>;
 +			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi0_pins_a>, <&spi0_cs0_pins_a>;
 +			clocks = <&bus_gates 20>, <&spi0_clk>;
 +			clock-names = "ahb", "mod";
 +			dmas = <&dma 23>, <&dma 23>;
@@ -169,6 +177,8 @@ index 8e7d38c..106204e 100644
 +			compatible = "allwinner,sun6i-a31-spi";
 +			reg = <0x01c69000 0x1000>;
 +			interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
 +			clocks = <&bus_gates 21>, <&spi1_clk>;
 +			clock-names = "ahb", "mod";
 +			dmas = <&dma 24>, <&dma 24>;


### PR DESCRIPTION
While doing tests with real hardware, although the /dev/i2c* were active, scan the bus wasn't working.
I've then compared with my previous DTS of 4.6.0 against 4.6.4, and figured out that those links where missing.
