### PR TITLE
fix a typo in I2C1 DTS

### DIFF
--- a/patch/kernel/sun8i-dev/add_missing_UARTs_I2Cs_SPI_for-H3.patch
+++ b/patch/kernel/sun8i-dev/add_missing_UARTs_I2Cs_SPI_for-H3.patch
@@ -136,7 +136,7 @@ index 8e7d38c..06aa68c 100644
 +			reg = <0x01c2b000 0x400>;
 +			interrupts = <GIC_SPI 7 IRQ_TYPE_LEVEL_HIGH>;
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c1_pins_a>;
 +			clocks = <&bus_gates 97>;
 +			resets = <&apb2_rst 1>;
 +			status = "disabled";


### PR DESCRIPTION
While doing some tests, I've found a glitch that I2C1 and I2C2 were using wrongly the same pins.
