### PR TITLE
add patch for new entries in /proc/cpuinfo to allow RPi.GPIO-PineA64 compatibility

### DIFF
--- a/patch/kernel/pine64-dev/add_proc_cpuinfo_entries_for_v4.7.x.patch
+++ b/patch/kernel/pine64-dev/add_proc_cpuinfo_entries_for_v4.7.x.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm64/kernel/cpuinfo.c b/arch/arm64/kernel/cpuinfo.c
+index 3808470..c929fc2 100644
+--- a/arch/arm64/kernel/cpuinfo.c
++++ b/arch/arm64/kernel/cpuinfo.c
+@@ -115,6 +115,8 @@ static int c_show(struct seq_file *m, void *v)
+ 		 * "processor".  Give glibc what it expects.
+ 		 */
+ 		seq_printf(m, "processor\t: %d\n", i);
++		seq_printf(m, "Processor : AArch64 Processor rev %d (aarch64)\n", MIDR_REVISION(midr));
++		seq_printf(m, "Hardware  : sun50iw1p1\n");
+ 
+ 		seq_printf(m, "BogoMIPS\t: %lu.%02lu\n",
+ 			   loops_per_jiffy / (500000UL/HZ),


### PR DESCRIPTION
While testing new kernel 4.7, I quickly figure out that RPi.GPIO-PineA64 wouldn't work anymore because it doesn't detect the PineA64 CPU. Looking at the code, I saw that it is looking at /proc/cpuinfo to figured out process time. I've compared with previous Longsleep kernel and create this patch to match the minimum.
