### PR TITLE
change the DTC version_gen.h tag to match 4.7.x

### DIFF
--- a/patch/kernel/sun8i-dev/scripts-dtc-Update-to-version-with-overlays.patch
+++ b/patch/kernel/sun8i-dev/scripts-dtc-Update-to-version-with-overlays.patch
@@ -4888,7 +4888,7 @@ index 11d93e6..03df694 100644
 --- a/scripts/dtc/version_gen.h
 +++ b/scripts/dtc/version_gen.h
 @@ -1 +1 @@
--#define DTC_VERSION "DTC 1.4.1-gb06e55c8"
+-#define DTC_VERSION "DTC 1.4.1-g53bf130b"
 +#define DTC_VERSION "DTC 1.4.1-g4273dca2"
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index ddf83d0..a0fb9e3 100644


### PR DESCRIPTION
The previous version tag from 4.6.x was producing a small patch rejection under 4.7.x, although the DTC compiled fine.