### PR TITLE
Fixed USB redirector building on kernels >4.4

### DIFF
--- a/extras/usb-redirector.sh
+++ b/extras/usb-redirector.sh
@@ -16,6 +16,11 @@ install_usb_redirector()
 	cd $SOURCES
 	if (( "${array[0]}" == "4" )) && (( "${array[1]}" >= "1" )); then
 		wget -q http://www.incentivespro.com/usb-redirector-linux-arm-eabi.tar.gz
+		if (( "${array[1]}" >= "4" )); then
+			EXTRA_BUILD_FLAGS="USE_EHCI_FIX=n VHCI=y STUB=n"
+		else
+			EXTRA_BUILD_FLAGS=""
+		fi
 	else
 		cp $SRC/lib/bin/usb-redirector-old.tgz usb-redirector-linux-arm-eabi.tar.gz
 	fi
@@ -26,7 +31,7 @@ install_usb_redirector()
 	# patch to work with newer kernels
 	sed -e "s/f_dentry/f_path.dentry/g" -i usbdcdev.c
 	if [[ $ARCH == *64* ]]; then ARCHITECTURE=arm64; else ARCHITECTURE=arm; fi
-	make -j1 ARCH=$ARCHITECTURE CROSS_COMPILE="$CCACHE $KERNEL_COMPILER" KERNELDIR=$SOURCES/$LINUXSOURCEDIR/ >> $DEST/debug/install.log 2>&1
+	make -j1 ARCH=$ARCHITECTURE CROSS_COMPILE="$CCACHE $KERNEL_COMPILER" KERNELDIR=$SOURCES/$LINUXSOURCEDIR/ $EXTRA_BUILD_FLAGS >> $DEST/debug/install.log 2>&1
 	# configure USB redirector
 	sed -e 's/%INSTALLDIR_TAG%/\/usr\/local/g' $SOURCES/usb-redirector-linux-arm-eabi/files/rc.usbsrvd > $SOURCES/usb-redirector-linux-arm-eabi/files/rc.usbsrvd1
 	sed -e 's/%PIDFILE_TAG%/\/var\/run\/usbsrvd.pid/g' $SOURCES/usb-redirector-linux-arm-eabi/files/rc.usbsrvd1 > $SOURCES/usb-redirector-linux-arm-eabi/files/rc.usbsrvd


### PR DESCRIPTION
Related to http://www.incentivespro.com/forum/viewtopic.php?t=1830
set extra build flags to avoid compilartion errors.

Error was:

inlining failed in call to always_inline ‘IIlIIIlII’: function body not
available

Signed-off-by: Stephan Linz <linz@li-pro.net>