### PR TITLE
Support new LED trigger for disk activity from kernel 4.8 on Cubietruck

### DIFF
--- a/debootstrap-ng.sh
+++ b/debootstrap-ng.sh
@@ -368,7 +368,14 @@ prepare_partitions()
 	# stage: mount image
 	# lock access to loop devices
 	exec {FD}>/var/lock/armbian-debootstrap-losetup
-	flock --verbose -x $FD | tee -a $DEST/debug/output.log
+	# verbose flock is supported since util-linux 2.27
+	local codename=$(lsb_release -sc)
+	if [[ $codename == wheezy || $codename == jessie \
+	   || $codename == precise || $codename == trusty ]]; then
+		flock -x $FD | tee -a $DEST/debug/output.log
+	else
+		flock --verbose -x $FD | tee -a $DEST/debug/output.log
+	fi
 
 	LOOP=$(losetup -f)
 	[[ -z $LOOP ]] && exit_with_error "Unable to find free loop device"


### PR DESCRIPTION
1. sunxi-next: backport from kernel 4.8 and enable in defconfig
2. sunxi-dev: update kernel defconfig with 4.8-rc8
3. cubietruck: enable disk trigger on orange LED
4. cubietruck: enable heartbeat trigger on white LED
