### PR TITLE
lime2-emmc: remove faulty emmc-reset IO pin

### DIFF
--- a/patch/kernel/sunxi-next/lime2-emmc-remove-powerseq.patch
+++ b/patch/kernel/sunxi-next/lime2-emmc-remove-powerseq.patch
@@ -1,0 +1,35 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2-emmc.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2-emmc.dts
+index 5ea4915..7e6b703 100644
+--- a/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2-emmc.dts
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2-emmc.dts
+@@ -46,22 +46,6 @@
+ / {
+ 	model = "Olimex A20-OLinuXino-LIME2-eMMC";
+ 	compatible = "olimex,a20-olinuxino-lime2-emmc", "allwinner,sun7i-a20";
+-
+-	mmc2_pwrseq: pwrseq {
+-		pinctrl-0 = <&mmc2_pins_nrst>;
+-		pinctrl-names = "default";
+-		compatible = "mmc-pwrseq-emmc";
+-		reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
+-	};
+-};
+-
+-&pio {
+-	mmc2_pins_nrst: mmc2@0 {
+-		allwinner,pins = "PC16";
+-		allwinner,function = "gpio_out";
+-		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+-		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+-	};
+ };
+ 
+ &mmc2 {
+@@ -71,7 +55,6 @@
+ 	vqmmc-supply = <&reg_vcc3v3>;
+ 	bus-width = <4>;
+ 	non-removable;
+-	mmc-pwrseq = <&mmc2_pwrseq>;
+ 	status = "okay";
+ 
+ 	emmc: emmc@0 {


### PR DESCRIPTION
As per chradev's forum post here: http://forum.armbian.com/index.php/topic/853-armbian-customization/page-7#entry16748

This patch is required to use the eMMC on the Lime2-emmc, since the addition of the reset pin in the upstream kernel device tree for this board.

I have an Armbian 5.21 successfully booting off microSD, running nand-sata-install.sh to install same onto eMMC and it also booting correctly. 
(With the caveat that now the eMMC seems to be detected by the kernel as mmcblk1 regardless of whether an SD card is inserted and so the boot script requires editing to set rootdev as mmcblk1p1 or using UUID. I will investigate further.)