### PR TITLE
Add patch for A20-CAN support on lime2 and lime2-emmc boards

### DIFF
--- a/patch/kernel/sunxi-next/lime2-add-A20-CAN-support.patch
+++ b/patch/kernel/sunxi-next/lime2-add-A20-CAN-support.patch
@@ -23,8 +23,8 @@ index bd0c476..8b63dde 100644
 +			can0_pins_a: can0@0 {
 +				allwinner,pins = "PH20","PH21";
 +				allwinner,function = "can";
-+				allwinner,drive = <0>;
-+				allwinner,pull = <0>;
++				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 +			};
 +
  			ps20_pins_a: ps20@0 {
@@ -37,7 +37,7 @@ index bd0c476..8b63dde 100644
 +		can0: can@01c2bc00 {
 +			compatible = "allwinner,sun4i-a10-can";
 +			reg = <0x01c2bc00 0x400>;
-+			interrupts = <0 26 4>;
++			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
 +			clocks = <&apb1_gates 4>;
 +			status = "disabled";
 +		};
@@ -45,33 +45,3 @@ index bd0c476..8b63dde 100644
  		ir0: ir@01c21800 {
  			compatible = "allwinner,sun4i-a10-ir";
  			clocks = <&apb0_gates 6>, <&ir0_clk>;
-diff --git a/drivers/net/can/Kconfig b/drivers/net/can/Kconfig
-index 22570ea..81cee10 100644
---- a/drivers/net/can/Kconfig
-+++ b/drivers/net/can/Kconfig
-@@ -136,6 +136,13 @@ config PCH_CAN
- 	  This driver is for PCH CAN of Topcliff (Intel EG20T PCH) which
- 	  is an IOH for x86 embedded processor (Intel Atom E6xx series).
- 	  This driver can access CAN bus.
-+	  
-+config CAN_SUN7I
-+	tristate "Sun7i CAN bus controller"
-+	default n
-+	---help---
-+	  This is the Sun7i CAN BUS driver for android system by peter chen.
-+
- 
- source "drivers/net/can/c_can/Kconfig"
- source "drivers/net/can/cc770/Kconfig"
-diff --git a/drivers/net/can/Makefile b/drivers/net/can/Makefile
-index 26ba4b7..ca59e8f 100644
---- a/drivers/net/can/Makefile
-+++ b/drivers/net/can/Makefile
-@@ -30,6 +30,7 @@ obj-$(CONFIG_CAN_SUN4I)		+= sun4i_can.o
- obj-$(CONFIG_CAN_TI_HECC)	+= ti_hecc.o
- obj-$(CONFIG_CAN_XILINXCAN)	+= xilinx_can.o
- obj-$(CONFIG_PCH_CAN)		+= pch_can.o
-+obj-$(CONFIG_CAN_SUN7I)		+= sun7i_can.o
- 
- subdir-ccflags-y += -D__CHECK_ENDIAN__
- subdir-ccflags-$(CONFIG_CAN_DEBUG_DEVICES) += -DDEBUG

--- a/patch/kernel/sunxi-next/lime2-add-A20-CAN-support.patch
+++ b/patch/kernel/sunxi-next/lime2-add-A20-CAN-support.patch
@@ -1,0 +1,77 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2.dts
+index d5c796c..2f90530 100644
+--- a/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2.dts
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-lime2.dts
+@@ -278,3 +278,9 @@
+ 	usb2_vbus-supply = <&reg_usb2_vbus>;
+ 	status = "okay";
+ };
++
++&can0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&can0_pins_a>;
++	status = "okay";
++};
+diff --git a/arch/arm/boot/dts/sun7i-a20.dtsi b/arch/arm/boot/dts/sun7i-a20.dtsi
+index bd0c476..8b63dde 100644
+--- a/arch/arm/boot/dts/sun7i-a20.dtsi
++++ b/arch/arm/boot/dts/sun7i-a20.dtsi
+@@ -1229,6 +1229,13 @@
+ 				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+ 			};
+ 
++			can0_pins_a: can0@0 {
++				allwinner,pins = "PH20","PH21";
++				allwinner,function = "can";
++				allwinner,drive = <0>;
++				allwinner,pull = <0>;
++			};
++
+ 			ps20_pins_a: ps20@0 {
+ 				allwinner,pins = "PI20", "PI21";
+ 				allwinner,function = "ps2";
+@@ -1435,6 +1442,14 @@
+ 			status = "disabled";
+ 		};
+ 
++		can0: can@01c2bc00 {
++			compatible = "allwinner,sun4i-a10-can";
++			reg = <0x01c2bc00 0x400>;
++			interrupts = <0 26 4>;
++			clocks = <&apb1_gates 4>;
++			status = "disabled";
++		};
++
+ 		ir0: ir@01c21800 {
+ 			compatible = "allwinner,sun4i-a10-ir";
+ 			clocks = <&apb0_gates 6>, <&ir0_clk>;
+diff --git a/drivers/net/can/Kconfig b/drivers/net/can/Kconfig
+index 22570ea..81cee10 100644
+--- a/drivers/net/can/Kconfig
++++ b/drivers/net/can/Kconfig
+@@ -136,6 +136,13 @@ config PCH_CAN
+ 	  This driver is for PCH CAN of Topcliff (Intel EG20T PCH) which
+ 	  is an IOH for x86 embedded processor (Intel Atom E6xx series).
+ 	  This driver can access CAN bus.
++	  
++config CAN_SUN7I
++	tristate "Sun7i CAN bus controller"
++	default n
++	---help---
++	  This is the Sun7i CAN BUS driver for android system by peter chen.
++
+ 
+ source "drivers/net/can/c_can/Kconfig"
+ source "drivers/net/can/cc770/Kconfig"
+diff --git a/drivers/net/can/Makefile b/drivers/net/can/Makefile
+index 26ba4b7..ca59e8f 100644
+--- a/drivers/net/can/Makefile
++++ b/drivers/net/can/Makefile
+@@ -30,6 +30,7 @@ obj-$(CONFIG_CAN_SUN4I)		+= sun4i_can.o
+ obj-$(CONFIG_CAN_TI_HECC)	+= ti_hecc.o
+ obj-$(CONFIG_CAN_XILINXCAN)	+= xilinx_can.o
+ obj-$(CONFIG_PCH_CAN)		+= pch_can.o
++obj-$(CONFIG_CAN_SUN7I)		+= sun7i_can.o
+ 
+ subdir-ccflags-y += -D__CHECK_ENDIAN__
+ subdir-ccflags-$(CONFIG_CAN_DEBUG_DEVICES) += -DDEBUG


### PR DESCRIPTION
The patch has been created using the guidelines on this page: https://www.olimex.com/wiki/A20-CAN
