### PR TITLE
Allow cutom KERNELBRANCH through CLI argument

### DIFF
--- a/config/sources/sun8i.conf
+++ b/config/sources/sun8i.conf
@@ -18,7 +18,9 @@ case $BRANCH in
 	
 	dev)
 	KERNELSOURCE='https://github.com/megous/linux'
-	KERNELBRANCH='branch:orange-pi-4.8'
+	if [[ -z $KERNELBRANCH ]]; then
+		KERNELBRANCH='branch:orange-pi-4.8'
+	fi
 	KERNELDIR='linux-sun8i-mainline'
 	;;
 esac


### PR DESCRIPTION
In order to easily test different branches, make the
KERNELBRANCH variable customizable without the need
to edit files

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>