### PR TITLE
add add_missing_SPI_for-H3_v4.9.x.patch, disabled for now, to be enabled when switching to 4.9.x

### DIFF
--- a/patch/kernel/sun8i-dev/add_missing_SPI_for-H3_v4.9.x.patch-disabled
+++ b/patch/kernel/sun8i-dev/add_missing_SPI_for-H3_v4.9.x.patch-disabled
@@ -1,0 +1,90 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index cc2a8b4..70b2607 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -50,6 +50,11 @@
+ / {
+ 	interrupt-parent = <&gic>;
+ 
++        aliases {
++               spi0 = &spi0;
++               spi1 = &spi1;
++        };
++
+ 	cpus {
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -398,6 +403,34 @@
+ 				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
+ 			};
+ 
++			spi0_pins_a: spi0@0 {
++				allwinner,pins = "PC0", "PC1", "PC2";
++				allwinner,function = "spi0";
++				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++			};
++
++			spi0_cs0_pins_a: spi0_cs0@0 {
++				allwinner,pins = "PC3";
++				allwinner,function = "spi0";
++				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++			};
++
++			spi1_pins_a: spi1@0 {
++				allwinner,pins = "PA15", "PA16", "PA14";
++				allwinner,function = "spi1";
++				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++			};
++
++			spi1_cs0_pins_a: spi1_cs0@0 {
++				allwinner,pins = "PA13";
++				allwinner,function = "spi1";
++				allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++				allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++			};
++
+ 			uart0_pins_a: uart0@0 {
+ 				allwinner,pins = "PA4", "PA5";
+ 				allwinner,function = "uart0";
+@@ -547,6 +580,38 @@
+ 			#size-cells = <0>;
+ 		};
+ 
++		spi0: spi@01c68000 {
++			compatible = "allwinner,sun6i-a31-spi";
++			reg = <0x01c68000 0x1000>;
++			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi0_pins_a>, <&spi0_cs0_pins_a>;
++			clocks = <&ccu CLK_BUS_SPI0>, <&ccu CLK_SPI0>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 23>, <&dma 23>;
++			dma-names = "rx", "tx";
++			resets = <&ccu RST_BUS_SPI0>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
++		spi1: spi@01c69000 {
++			compatible = "allwinner,sun6i-a31-spi";
++			reg = <0x01c69000 0x1000>;
++			interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
++			clocks = <&ccu CLK_BUS_SPI1>, <&ccu CLK_SPI1>;
++			clock-names = "ahb", "mod";
++			dmas = <&dma 24>, <&dma 24>;
++			dma-names = "rx", "tx";
++			resets = <&ccu RST_BUS_SPI1>;
++			status = "disabled";
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++
+ 		emac: ethernet@1c30000 {
+ 			compatible = "allwinner,sun8i-h3-emac";
+ 			syscon = <&syscon>;


### PR DESCRIPTION
This file will replace the old one : add_missing_UARTs_I2Cs_SPI_for-H3.patch.disabled
