### PR TITLE
OPI Zero: Enable SPI1 by default to match schematic labeling

### DIFF
--- a/config/fex/orangepizero.fex
+++ b/config/fex/orangepizero.fex
@@ -195,7 +195,7 @@ spi_sclk = port:PC02<3><default><default><default>
 spi_cs0 = port:PC03<3><1><default><default>
 
 [spi1]
-spi_used = 0
+spi_used = 1
 spi_cs_bitmap = 1
 spi_cs0 = port:PA13<2><1><default><default>
 spi_sclk = port:PA14<2><default><default><default>
@@ -203,12 +203,21 @@ spi_mosi = port:PA15<2><default><default><default>
 spi_miso = port:PA16<2><default><default><default>
 
 [spi_devices]
-spi_dev_num = 1
+spi_dev_num = 2
 
 [spi_board0]
 modalias = "spidev"
 max_speed_hz = 33000000
 bus_num = 0
+chip_select = 0
+mode = 0
+full_duplex = 1
+manual_cs = 0
+
+[spi_board1]
+modalias = "spidev"
+max_speed_hz = 33000000
+bus_num = 1
 chip_select = 0
 mode = 0
 full_duplex = 1


### PR DESCRIPTION
Typically OPI/BPI boards have SPI0 on the headers.

However, the OPI Zero schematics show SPI1 on the EXT Port headers.  

(As a note: For OPI Zero, SPI0 went to support flash)

So it could make some sense to enable SPI1 to make the default operation match common pinout diagrams and schematic labeling.

What do you think?