### PR TITLE
Add sy8106a driver to SPL

### DIFF
--- a/patch/u-boot/u-boot-sun50i-dev/add-sy8106a.patch
+++ b/patch/u-boot/u-boot-sun50i-dev/add-sy8106a.patch
@@ -1,0 +1,22 @@
+diff --git a/u-boot/drivers/power/Kconfig b/u-boot/drivers/power/Kconfig
+index f2c5629..e0c548c 100644
+--- a/u-boot/drivers/power/Kconfig
++++ b/u-boot/drivers/power/Kconfig
+@@ -60,7 +60,7 @@ config AXP818_POWER
+ 
+ config SY8106A_POWER
+ 	bool "SY8106A pmic support"
+-	depends on MACH_SUN8I_H3
++	depends on MACH_SUN8I_H3 || MACH_SUN50I_H5
+ 	---help---
+ 	Select this to enable support for the SY8106A pmic found on some
+ 	H3 boards.
+diff --git a/u-boot/configs/sun50i_h5_spl32_defconfig b/u-boot/configs/sun50i_h5_spl32_defconfig
+index c73efd5..456a7a3 100644
+--- a/u-boot/configs/sun50i_h5_spl32_defconfig
++++ b/u-boot/configs/sun50i_h5_spl32_defconfig
+@@ -15,2 +15,4 @@ # CONFIG_CMD_IMLS is not set
+ # CONFIG_CMD_FLASH is not set
+ # CONFIG_CMD_FPGA is not set
++CONFIG_SPL_I2C_SUPPORT=y
++CONFIG_SY8106A_POWER=y


### PR DESCRIPTION
The selection of this driver makes sure the SPL reverts to 1200mV when it boots so there isn't an under voltage while rebooting.