### PR TITLE
Alter Cooling map

### DIFF
--- a/patch/kernel/sun50iw2-dev/add-DVFS-and-THS-DT-H5.patch
+++ b/patch/kernel/sun50iw2-dev/add-DVFS-and-THS-DT-H5.patch
@@ -144,7 +144,7 @@ index 37ac1708..0ccdcaa1 100644
 +		>;
 +	#cooling-cells = <2>;
 +	cooling-min-level = <0>;
-+	cooling-max-level = <15>;
++	cooling-max-level = <24>;
 +	cpu0-supply = <&vdd_cpu>;
 +};
 +
@@ -175,15 +175,15 @@ index 37ac1708..0ccdcaa1 100644
 +	cooling-maps {
 +		cpu_warm_limit_cpu {
 +			trip = <&cpu_warm>;
-+			cooling-device = <&cpu0 THERMAL_NO_LIMIT 10>;
++			cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
 +		};
 +		cpu_hot_limit_cpu {
 +			trip = <&cpu_hot>;
-+			cooling-device = <&cpu0 12 12>;
++			cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
 +		};
 +		cpu_very_hot_limit_cpu {
 +			trip = <&cpu_very_hot>;
-+			cooling-device = <&cpu0 14 THERMAL_NO_LIMIT>;
++			cooling-device = <&cpu0 18 THERMAL_NO_LIMIT>; /* Limit cpu speed above 90C to 720MHz */
 +		};
 +	};
 +};


### PR DESCRIPTION
Alter Cooling map to give governor more control and limit above 90C to 720MHz

This way the cooling table can do a better job at choosing the right frequency, since different environments ask for a different cooling table. Using these settings the target temperature is between 65 and 75C and it can reach that by selecting any of the frequencies available. 

If the temperature reaches 90C a more aggressive cooling table kicks in and limits the frequency to 720MHz. Could be lowered if needed, but 720MHz is slow enough to keep the SoC from heating up any more and even cool down a bit.