### PR TITLE
Change format option for mkfs.vfat in nand-sata-install.sh

### DIFF
--- a/scripts/nand-sata-install/usr/lib/nand-sata-install/nand-sata-install.sh
+++ b/scripts/nand-sata-install/usr/lib/nand-sata-install/nand-sata-install.sh
@@ -285,7 +285,8 @@ formatnand()
 	else
 		(echo y;) | sunxi-nand-part -f a10 /dev/nand 65536 'bootloader 65536' 'linux 0' >> $logfile 2>&1
 	fi
-	mkfs.vfat -qF /dev/nand1 >> $logfile 2>&1
+	# The option -qF does not exist on mkfs.vfat
+	mkfs.vfat -F /dev/nand1 >> $logfile 2>&1
 	mkfs.ext4 -qF /dev/nand2 >> $logfile 2>&1
 }
 


### PR DESCRIPTION
Change format in the "formatnand()" method in nand-sata-install.sh on line 289.

`mkfs.vfat -qF /dev/nand1 >> $logfile 2>&1`
to 
`mkfs.vfat -F /dev/nand1 >> $logfile 2>&1`

The option -qF does not exist so the boot can not work.
https://i.imgsafe.org/a17107eed2.jpg
Src :  https://linux.die.net/man/8/mkfs.vfat
Resolved post : 
https://forum.armbian.com/index.php/topic/3481-cubieboard-a20-2012-version-does-not-boot-with-armbian-525/?p=25060
https://forum.armbian.com/index.php/topic/3492-pcduino-3-cant-boot-from-nand

Thanks a lot for your job

Kinbald

