### PR TITLE
tinkerboard u_boot write to use .bin instead of .img

### DIFF
--- a/config/sources/rockchip.conf
+++ b/config/sources/rockchip.conf
@@ -55,7 +55,7 @@ if [[ $BOARD == "tinkerboard" ]]; then
 	{
 		dd if=/dev/zero of=$2 bs=1k count=1023 seek=1 status=noxfer > /dev/null 2>&1
 		mkimage -n rk3288 -T rksd -d $1/u-boot-spl-dtb.bin $1/out > /dev/null 2>&1
-		cat $1/u-boot-dtb.img >> $1/out > /dev/null 2>&1
+		cat $1/u-boot-dtb.bin >> $1/out > /dev/null 2>&1
 		dd if=$1/out of=$2 seek=64 conv=notrunc > /dev/null 2>&1
 	}
 fi


### PR DESCRIPTION
from

-		cat $1/u-boot-dtb.img >> $1/out > /dev/null 2>&1

to

+		cat $1/u-boot-dtb.bin >> $1/out > /dev/null 2>&1

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
