### PR TITLE
tinkerboard fix "cat" command in write_uboot_platform

### DIFF
--- a/config/sources/rockchip.conf
+++ b/config/sources/rockchip.conf
@@ -55,7 +55,7 @@ if [[ $BOARD == "tinkerboard" ]]; then
 	{
 		dd if=/dev/zero of=$2 bs=1k count=1023 seek=1 status=noxfer > /dev/null 2>&1
 		mkimage -n rk3288 -T rksd -d $1/u-boot-spl-dtb.bin $1/out > /dev/null 2>&1
-		cat $1/u-boot-dtb.bin >> $1/out > /dev/null 2>&1
+		cat $1/u-boot-dtb.bin >> $1/out 
 		dd if=$1/out of=$2 seek=64 conv=notrunc > /dev/null 2>&1
 	}
 fi


### PR DESCRIPTION
the "> /dev/null 2<&1" was being interpreted by cat instead of the shell as a command to throw the operation into the abyss.  The dtb was therefor not being written to the "out" file and not making into the final image.

"cat" has no console output in this case, so there's nothing to hide from it anyway.