### PR TITLE
Tinker:  Return to mainline U-boot

### DIFF
--- a/config/sources/rockchip.conf
+++ b/config/sources/rockchip.conf
@@ -43,13 +43,9 @@ if [[ $BOARD == "tinkerboard" ]]; then
 
 	UBOOT_TARGET_MAP=";;$SRC/lib/bin/rk3288_boot.bin u-boot-dtb.bin spl/u-boot-spl-dtb.bin"
 
-	#BOOTSOURCE=$MAINLINE_UBOOT_SOURCE
-	#BOOTDIR=$MAINLINE_UBOOT_DIR
-	#BOOTBRANCH="branch:master"
-	# mainline uboot currently doesn't work
-	BOOTSOURCE='https://github.com/rockchip-linux/u-boot.git'
-	BOOTDIR='u-boot-rk-linux'
-	BOOTBRANCH="branch:release"
+	BOOTSOURCE=$MAINLINE_UBOOT_SOURCE
+	BOOTDIR=$MAINLINE_UBOOT_DIR
+	BOOTBRANCH="branch:master"
 
 	write_uboot_platform()
 	{


### PR DESCRIPTION
U-boot mainline tested working.

```
U-Boot SPL 2017.05-rc1-armbian (Apr 17 2017 - 00:30:20)


U-Boot 2017.05-rc1-armbian (Apr 17 2017 - 00:30:20 -0400)

Model: Tinker-RK3288
DRAM:  2 GiB
MMC:   dwmmc@ff0c0000: 1
```
